### PR TITLE
feature/account-transaction-rework

### DIFF
--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/controller/AccountController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/controller/AccountController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountCreateDto;
+import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountRequestDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.service.AccountService;
 
 import jakarta.validation.Valid;
@@ -21,7 +21,7 @@ public class AccountController {
     private AccountService accountService;
 
     @PostMapping("/register")
-    public ResponseEntity<?> create(@Valid @RequestBody AccountCreateDto accountDto){
+    public ResponseEntity<?> create(@Valid @RequestBody AccountRequestDto accountDto){
         return ResponseEntity.status(HttpStatus.CREATED).body(accountService.save(accountDto));
     }
 

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/dto/AccountAdminResponseDto.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/dto/AccountAdminResponseDto.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 
 import com.crhistianm.springboot.gallo.springboot_gallo.entity.Audit;
-import com.crhistianm.springboot.gallo.springboot_gallo.entity.Person;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 //Without password as password is just for writing
@@ -20,8 +19,10 @@ public class AccountAdminResponseDto implements AccountResponseDto{
     @JsonIgnoreProperties({"accounts", "handler", "hibernateLazyInitializer"})
     private List<RoleResponseDto> roles;
 
+    //Ignore account as is already shown in this dto class(otherwise it will generate a infinite loop)
+    @JsonIgnoreProperties({"account", "handler", "hibernateLazyInitializer"})
     //Here i add the person to return it as it will be used on administration
-    private Person person;
+    private PersonResponseDto person;
 
     //As response will show when it was updated/created
     private Audit audit;
@@ -30,7 +31,7 @@ public class AccountAdminResponseDto implements AccountResponseDto{
         this.roles = new ArrayList<>();
     }
 
-    public AccountAdminResponseDto(Long id, String email, Person person, Audit audit) {
+    public AccountAdminResponseDto(Long id, String email, PersonResponseDto person, Audit audit) {
         this();
         this.id = id;
         this.email = email;
@@ -73,11 +74,11 @@ public class AccountAdminResponseDto implements AccountResponseDto{
         this.roles = roles;
     }
 
-    public Person getPerson() {
+    public PersonResponseDto getPerson() {
         return person;
     }
 
-    public void setPerson(Person person) {
+    public void setPerson(PersonResponseDto person) {
         this.person = person;
     }
 

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/dto/AccountAdminResponseDto.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/dto/AccountAdminResponseDto.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.entity.Audit;
 import com.crhistianm.springboot.gallo.springboot_gallo.entity.Person;
-import com.crhistianm.springboot.gallo.springboot_gallo.entity.Role;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 //Without password as password is just for writing
@@ -17,9 +16,9 @@ public class AccountAdminResponseDto implements AccountResponseDto{
 
     private String email;
 
-    //JsonIgnoreProperties to avoid infinte loop of roles and accounts
+    //Ignore list of accounts per role
     @JsonIgnoreProperties({"accounts", "handler", "hibernateLazyInitializer"})
-    private List<Role> roles;
+    private List<RoleResponseDto> roles;
 
     //Here i add the person to return it as it will be used on administration
     private Person person;
@@ -66,11 +65,11 @@ public class AccountAdminResponseDto implements AccountResponseDto{
         this.audit = audit;
     }
 
-    public List<Role> getRoles() {
+    public List<RoleResponseDto> getRoles() {
         return roles;
     }
 
-    public void setRoles(List<Role> roles) {
+    public void setRoles(List<RoleResponseDto> roles) {
         this.roles = roles;
     }
 

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/dto/AccountRequestDto.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/dto/AccountRequestDto.java
@@ -11,7 +11,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 //Id not in dto as it is auto incremental on db
-public class AccountCreateDto{
+public class AccountRequestDto{
 
     @NotNull
     @PersonNotAssigned
@@ -29,10 +29,10 @@ public class AccountCreateDto{
     @AdminRequired
     private boolean admin;
 
-    public AccountCreateDto() {
+    public AccountRequestDto() {
     }
 
-    public AccountCreateDto(String email, String password, Long personId, boolean admin) {
+    public AccountRequestDto(String email, String password, Long personId, boolean admin) {
         this.email = email;
         this.password = password;
         this.admin = admin;
@@ -88,7 +88,7 @@ public class AccountCreateDto{
             return false;
         if (getClass() != obj.getClass())
             return false;
-        AccountCreateDto other = (AccountCreateDto) obj;
+        AccountRequestDto other = (AccountRequestDto) obj;
         if (personId == null) {
             if (other.personId != null)
                 return false;
@@ -104,7 +104,7 @@ public class AccountCreateDto{
 
     @Override
     public String toString() {
-        return "AccountCreateDto [personId=" + personId + ", email=" + email + ", password=" + password + ", admin="
+        return "AccountRequestDto [personId=" + personId + ", email=" + email + ", password=" + password + ", admin="
                 + admin + "]";
     }
 

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/dto/RoleResponseDto.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/dto/RoleResponseDto.java
@@ -1,46 +1,36 @@
-package com.crhistianm.springboot.gallo.springboot_gallo.entity;
+package com.crhistianm.springboot.gallo.springboot_gallo.dto;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.Table;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-@Entity
-@Table(name = "role")
-public class Role {
+public class RoleResponseDto {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true)
     private String name;
 
-    //Created inverse relationship as i need to query how many users have roles 
-    @ManyToMany(mappedBy = "roles")
-    private List<Account> accounts;
+    //Only display id and email from list of accounts
+    @JsonIgnoreProperties({"roles", "audit", "person", "handler", "hibernateLazyInitializer"})
+    List<AccountAdminResponseDto> accounts;
 
-    public Role(){
+    public RoleResponseDto() {
         this.accounts = new ArrayList<>();
     }
 
-    public Role(String name) {
+    public RoleResponseDto(Long id, String name) {
         this();
+        this.id = id;
         this.name = name;
-    }
-
-    public Long getId() {
-        return id;
     }
 
     public void setId(Long id) {
         this.id = id;
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public String getName() {
@@ -51,14 +41,13 @@ public class Role {
         this.name = name;
     }
 
-    public void setAccounts(List<Account> accounts) {
+    public void setAccounts(List<AccountAdminResponseDto> accounts) {
         this.accounts = accounts;
     }
 
-    public List<Account> getAccounts() {
+    public List<AccountAdminResponseDto> getAccounts() {
         return accounts;
     }
-
 
     @Override
     public int hashCode() {
@@ -77,7 +66,7 @@ public class Role {
             return false;
         if (getClass() != obj.getClass())
             return false;
-        Role other = (Role) obj;
+        RoleResponseDto other = (RoleResponseDto) obj;
         if (id == null) {
             if (other.id != null)
                 return false;
@@ -93,7 +82,7 @@ public class Role {
 
     @Override
     public String toString() {
-        return "Role {id=" + id + ", name=" + name + "}";
+        return "RoleResponseDto [id=" + id + ", name=" + name + ", accounts=" + accounts + "]";
     }
 
 }

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/mapper/AccountMapper.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/mapper/AccountMapper.java
@@ -27,17 +27,17 @@ public class AccountMapper {
             RoleResponseDto roleDto = new RoleResponseDto();
             roleDto.setId(role.getId());
             roleDto.setName(role.getName());
-            List<AccountAdminResponseDto> accountList = new ArrayList<>();
-
-            //Just add id and email as is the only information needed
-            for (Account iterate: role.getAccounts()) {
-                AccountAdminResponseDto accountAdminResponseDto = new AccountAdminResponseDto();
-                accountAdminResponseDto.setId(iterate.getId());
-                accountAdminResponseDto.setEmail(iterate.getEmail());
-                accountList.add(accountAdminResponseDto);
+            if(role.getAccounts() != null){
+                List<AccountAdminResponseDto> accountList = new ArrayList<>();
+                //Just add id and email as is the only information needed
+                for (Account iterate: role.getAccounts()) {
+                    AccountAdminResponseDto accountAdminResponseDto = new AccountAdminResponseDto();
+                    accountAdminResponseDto.setId(iterate.getId());
+                    accountAdminResponseDto.setEmail(iterate.getEmail());
+                    accountList.add(accountAdminResponseDto);
+                }
+                roleDto.setAccounts(accountList);
             }
-            roleDto.setAccounts(accountList);
-
             return roleDto;
         }).collect(Collectors.toList());
         accountDto.setId(account.getId());

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/mapper/AccountMapper.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/mapper/AccountMapper.java
@@ -1,10 +1,15 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.mapper;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.crhistianm.springboot.gallo.springboot_gallo.builder.AccountBuilder;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountAdminResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountCreateDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountUserResponseDto;
+import com.crhistianm.springboot.gallo.springboot_gallo.dto.RoleResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.entity.Account;
 
 public class AccountMapper {
@@ -15,11 +20,29 @@ public class AccountMapper {
 
     public static AccountResponseDto entityToAdminResponse(Account account){
         AccountAdminResponseDto accountDto = new AccountAdminResponseDto();
+        //List<RoleResponseDto> rolesResponseDto = account.getRoles().stream().map(r -> new RoleResponseDto(r.getId(), r.getName())).collect(Collectors.toList());
+        List<RoleResponseDto> rolesResponseDto = account.getRoles().stream().map(role -> {
+            RoleResponseDto roleDto = new RoleResponseDto();
+            roleDto.setId(role.getId());
+            roleDto.setName(role.getName());
+            List<AccountAdminResponseDto> accountList = new ArrayList<>();
+
+            //Just add id and email as is the only information needed
+            for (Account iterate: role.getAccounts()) {
+                AccountAdminResponseDto accountAdminResponseDto = new AccountAdminResponseDto();
+                accountAdminResponseDto.setId(iterate.getId());
+                accountAdminResponseDto.setEmail(iterate.getEmail());
+                accountList.add(accountAdminResponseDto);
+            }
+            roleDto.setAccounts(accountList);
+
+            return roleDto;
+        }).collect(Collectors.toList());
         accountDto.setId(account.getId());
         accountDto.setEmail(account.getEmail());
-        accountDto.setRoles(account.getRoles());
-        accountDto.setPerson(account.getPerson());
+        accountDto.setRoles(rolesResponseDto);
         accountDto.setAudit(account.getAudit());
+        accountDto.setPerson(account.getPerson());
         return accountDto;
     }
     

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/mapper/AccountMapper.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/mapper/AccountMapper.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.builder.AccountBuilder;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountAdminResponseDto;
-import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountCreateDto;
+import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountRequestDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountUserResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.RoleResponseDto;
@@ -14,7 +14,7 @@ import com.crhistianm.springboot.gallo.springboot_gallo.entity.Account;
 
 public class AccountMapper {
 
-    public static Account requestToEntity(AccountCreateDto accountDto){
+    public static Account requestToEntity(AccountRequestDto accountDto){
         return new AccountBuilder().email(accountDto.getEmail()).password(accountDto.getPassword()).build();
     }
 

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/mapper/AccountMapper.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/mapper/AccountMapper.java
@@ -19,6 +19,8 @@ public class AccountMapper {
     }
 
     public static AccountResponseDto entityToAdminResponse(Account account){
+        //Set account to null as this response does not need account from person entity
+        account.getPerson().setAccount(null);
         AccountAdminResponseDto accountDto = new AccountAdminResponseDto();
         //List<RoleResponseDto> rolesResponseDto = account.getRoles().stream().map(r -> new RoleResponseDto(r.getId(), r.getName())).collect(Collectors.toList());
         List<RoleResponseDto> rolesResponseDto = account.getRoles().stream().map(role -> {
@@ -42,7 +44,7 @@ public class AccountMapper {
         accountDto.setEmail(account.getEmail());
         accountDto.setRoles(rolesResponseDto);
         accountDto.setAudit(account.getAudit());
-        accountDto.setPerson(account.getPerson());
+        accountDto.setPerson(PersonMapper.entityToResponse(account.getPerson()));
         return accountDto;
     }
     

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/service/AccountService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/service/AccountService.java
@@ -1,12 +1,12 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.service;
 
 
-import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountCreateDto;
+import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountRequestDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountResponseDto;
 
 public interface AccountService {
 
-    AccountResponseDto save(AccountCreateDto accountDto);
+    AccountResponseDto save(AccountRequestDto accountDto);
     
     boolean isEmailAvailable(String email);
 

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/service/AccountServiceImpl.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/service/AccountServiceImpl.java
@@ -9,7 +9,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountCreateDto;
+import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountRequestDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.entity.Account;
 import com.crhistianm.springboot.gallo.springboot_gallo.entity.Person;
@@ -39,7 +39,7 @@ public class AccountServiceImpl implements AccountService{
 
     @Transactional
     @Override
-    public AccountResponseDto save(AccountCreateDto accountDto) {
+    public AccountResponseDto save(AccountRequestDto accountDto) {
         Optional<Role> optionalRoleUser = roleRepository.findByName("ROLE_USER");
 
         System.out.println(accountDto);

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/controller/AccountControllerTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/controller/AccountControllerTest.java
@@ -19,7 +19,7 @@ import static com.crhistianm.springboot.gallo.springboot_gallo.data.Data.*;
 import com.crhistianm.springboot.gallo.springboot_gallo.builder.PersonBuilder;
 import com.crhistianm.springboot.gallo.springboot_gallo.config.JacksonConfig;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountAdminResponseDto;
-import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountCreateDto;
+import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountRequestDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.entity.Person;
 import com.crhistianm.springboot.gallo.springboot_gallo.mapper.PersonMapper;
 import com.crhistianm.springboot.gallo.springboot_gallo.security.SpringSecurityConfig;
@@ -48,7 +48,7 @@ public class AccountControllerTest {
     
     @Test
     void testCreate() throws Exception{
-        AccountCreateDto accountDto = givenAdminAccountCreateDto().orElseThrow(); 
+        AccountRequestDto accountDto = givenAdminAccountRequestDto().orElseThrow(); 
 
         Person person = new PersonBuilder().id(1L).build();
         AccountAdminResponseDto accountResponseDto = new AccountAdminResponseDto();

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/controller/AccountControllerTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/controller/AccountControllerTest.java
@@ -21,6 +21,7 @@ import com.crhistianm.springboot.gallo.springboot_gallo.config.JacksonConfig;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountAdminResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountCreateDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.entity.Person;
+import com.crhistianm.springboot.gallo.springboot_gallo.mapper.PersonMapper;
 import com.crhistianm.springboot.gallo.springboot_gallo.security.SpringSecurityConfig;
 import com.crhistianm.springboot.gallo.springboot_gallo.service.AccountService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -52,7 +53,7 @@ public class AccountControllerTest {
         Person person = new PersonBuilder().id(1L).build();
         AccountAdminResponseDto accountResponseDto = new AccountAdminResponseDto();
         accountResponseDto.setEmail("erikadmin@gmail.com");
-        accountResponseDto.setPerson(person);
+        accountResponseDto.setPerson(PersonMapper.entityToResponse(person));
             
 
         //It is a different instance as objectMapper changes it obviously

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/data/Data.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/data/Data.java
@@ -12,6 +12,7 @@ import com.crhistianm.springboot.gallo.springboot_gallo.builder.PersonBuilder;
 import com.crhistianm.springboot.gallo.springboot_gallo.builder.RoleBuilder;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountRequestDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.PersonRequestDto;
+import com.crhistianm.springboot.gallo.springboot_gallo.dto.RoleResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.entity.Account;
 import com.crhistianm.springboot.gallo.springboot_gallo.entity.Audit;
 import com.crhistianm.springboot.gallo.springboot_gallo.entity.Person;
@@ -64,6 +65,14 @@ public class Data {
     public static Optional<Role> givenRoleUser(){
         return Optional.of(new RoleBuilder().name("ROLE_USER").build());
     }
+
+    public static Optional<RoleResponseDto> givenRoleResponseDtoAdmin(){
+        return Optional.of(new RoleResponseDto(null, "ROLE_ADMIN"));
+    }
+    public static Optional<RoleResponseDto> givenRoleResponseDtoUser(){
+        return Optional.of(new RoleResponseDto(null, "ROLE_USER"));
+    }
+
 
     public static Optional<Account> givenAccountEntityAdmin(){
         Audit audit = new Audit();

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/data/Data.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/data/Data.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 import com.crhistianm.springboot.gallo.springboot_gallo.builder.AccountBuilder;
 import com.crhistianm.springboot.gallo.springboot_gallo.builder.PersonBuilder;
 import com.crhistianm.springboot.gallo.springboot_gallo.builder.RoleBuilder;
-import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountCreateDto;
+import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountRequestDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.PersonRequestDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.entity.Account;
 import com.crhistianm.springboot.gallo.springboot_gallo.entity.Audit;
@@ -20,16 +20,16 @@ import com.crhistianm.springboot.gallo.springboot_gallo.mapper.PersonMapper;
 
 public class Data {
 
-    public static Optional<AccountCreateDto> givenUserAccountCreateDto(){
-        AccountCreateDto accountCreateDto = new AccountCreateDto();
+    public static Optional<AccountRequestDto> givenUserAccountRequestDto(){
+        AccountRequestDto accountCreateDto = new AccountRequestDto();
         accountCreateDto.setEmail("erikuser@gmail.com");
         accountCreateDto.setPassword("12345");
         accountCreateDto.setPersonId(1L);
         return Optional.of(accountCreateDto);
     }
 
-    public static Optional<AccountCreateDto> givenAdminAccountCreateDto(){
-        AccountCreateDto accountCreateDto = new AccountCreateDto();
+    public static Optional<AccountRequestDto> givenAdminAccountRequestDto(){
+        AccountRequestDto accountCreateDto = new AccountRequestDto();
         accountCreateDto.setEmail("erikadmin@gmail.com");
         accountCreateDto.setPassword("12345");
         accountCreateDto.setPersonId(2L);

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/service/AccountServiceImplUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/service/AccountServiceImplUnitTest.java
@@ -22,6 +22,7 @@ import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountAdminResponse
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountRequestDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountUserResponseDto;
+import com.crhistianm.springboot.gallo.springboot_gallo.dto.PersonResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.entity.Account;
 import com.crhistianm.springboot.gallo.springboot_gallo.entity.Person;
 import com.crhistianm.springboot.gallo.springboot_gallo.mapper.AccountMapper;
@@ -89,7 +90,7 @@ class AccountServiceImplUnitTest {
 
             //Both roles
             assertTrue(accountResponseDto instanceof AccountAdminResponseDto);
-            assertEquals(Arrays.asList(givenRoleUser().orElseThrow(), givenRoleAdmin().orElseThrow()), accountAdminResponseDto.getRoles());
+            assertEquals(Arrays.asList(givenRoleResponseDtoUser().orElseThrow(), givenRoleResponseDtoAdmin().orElseThrow()), accountAdminResponseDto.getRoles());
             verify(roleRepository, times(2)).findByName(anyString());
         }
 
@@ -100,7 +101,7 @@ class AccountServiceImplUnitTest {
 
 
             AccountAdminResponseDto accountAdminResponseDto = (AccountAdminResponseDto) accountServiceImpl.save(accountCreateDto);
-            Person answer = PersonMapper.requestToEntity(givenPersonRequestDtoOne().orElseThrow());
+            PersonResponseDto answer = PersonMapper.entityToResponse(PersonMapper.requestToEntity(givenPersonRequestDtoOne().orElseThrow()));
             answer.setId(1L);
             //Per person test
             assertNotNull(accountAdminResponseDto.getPerson());

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/service/AccountServiceImplUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/service/AccountServiceImplUnitTest.java
@@ -19,7 +19,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import com.crhistianm.springboot.gallo.springboot_gallo.builder.PersonBuilder;
 import static com.crhistianm.springboot.gallo.springboot_gallo.data.Data.*;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountAdminResponseDto;
-import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountCreateDto;
+import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountRequestDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountUserResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.entity.Account;
@@ -69,7 +69,7 @@ class AccountServiceImplUnitTest {
         @Test
         void testAssignRoleUser() {
             when(roleRepository.findByName("ROLE_USER")).thenReturn(givenRoleUser());
-            AccountCreateDto accountUserDto = givenUserAccountCreateDto().orElseThrow();
+            AccountRequestDto accountUserDto = givenUserAccountRequestDto().orElseThrow();
 
             //One role
             assertTrue(accountServiceImpl.save(accountUserDto) instanceof AccountUserResponseDto);
@@ -81,7 +81,7 @@ class AccountServiceImplUnitTest {
         void testAssignRoleAdmin() {
             when(roleRepository.findByName("ROLE_USER")).thenReturn(givenRoleUser());
             when(roleRepository.findByName("ROLE_ADMIN")).thenReturn(givenRoleAdmin());
-            AccountCreateDto accountAdminDto = givenAdminAccountCreateDto().orElseThrow();
+            AccountRequestDto accountAdminDto = givenAdminAccountRequestDto().orElseThrow();
 
             AccountResponseDto accountResponseDto = accountServiceImpl.save(accountAdminDto);
 
@@ -96,7 +96,7 @@ class AccountServiceImplUnitTest {
         @DisplayName("Testing service person assignment")
         @Test
         void testAssignPerson(){
-            AccountCreateDto accountCreateDto = givenAdminAccountCreateDto().orElseThrow();
+            AccountRequestDto accountCreateDto = givenAdminAccountRequestDto().orElseThrow();
 
 
             AccountAdminResponseDto accountAdminResponseDto = (AccountAdminResponseDto) accountServiceImpl.save(accountCreateDto);
@@ -145,7 +145,7 @@ class AccountServiceImplUnitTest {
             void setUp(){
                 when(accountRepository.findAccountByPersonId(anyLong())).thenAnswer(invo ->{
                     Optional<Account> account = Optional.empty();
-                    if(invo.getArgument(0, Long.class) == 1L) account = Optional.of(AccountMapper.requestToEntity(givenUserAccountCreateDto().orElseThrow()));
+                    if(invo.getArgument(0, Long.class) == 1L) account = Optional.of(AccountMapper.requestToEntity(givenUserAccountRequestDto().orElseThrow()));
                     return account;
                 });
             }

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/validation/dto/AccountRequestDtoAnnotationTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/validation/dto/AccountRequestDtoAnnotationTest.java
@@ -1,7 +1,7 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.validation.dto;
 
-import static com.crhistianm.springboot.gallo.springboot_gallo.data.Data.givenAdminAccountCreateDto;
-import static com.crhistianm.springboot.gallo.springboot_gallo.data.Data.givenUserAccountCreateDto;
+import static com.crhistianm.springboot.gallo.springboot_gallo.data.Data.givenAdminAccountRequestDto;
+import static com.crhistianm.springboot.gallo.springboot_gallo.data.Data.givenUserAccountRequestDto;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
@@ -23,7 +23,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 
-import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountCreateDto;
+import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountRequestDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.service.AccountServiceImpl;
 import com.crhistianm.springboot.gallo.springboot_gallo.service.PersonServiceImpl;
 
@@ -31,12 +31,12 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 
 @SpringBootTest
-public class AccountCreateDtoAnnotationTest{
+public class AccountRequestDtoAnnotationTest{
 
     @Autowired
     private Validator validator;
 
-    private AccountCreateDto account;
+    private AccountRequestDto account;
 
     @MockitoBean
     private PersonServiceImpl personService;
@@ -44,7 +44,7 @@ public class AccountCreateDtoAnnotationTest{
     @MockitoBean
     private AccountServiceImpl accountService;
 
-    Set<ConstraintViolation<AccountCreateDto>> violations;
+    Set<ConstraintViolation<AccountRequestDto>> violations;
 
     @BeforeEach
     void setUp(){
@@ -59,7 +59,7 @@ public class AccountCreateDtoAnnotationTest{
 
         @BeforeEach
         void setUp(){
-            account = givenUserAccountCreateDto().orElseThrow();
+            account = givenUserAccountRequestDto().orElseThrow();
         }
 
         @Test
@@ -118,7 +118,7 @@ public class AccountCreateDtoAnnotationTest{
         
         @BeforeEach
         void setUp(){
-            account = givenUserAccountCreateDto().orElseThrow();
+            account = givenUserAccountRequestDto().orElseThrow();
         }
 
         @Test
@@ -176,7 +176,7 @@ public class AccountCreateDtoAnnotationTest{
 
         @BeforeEach
         void setUp(){
-            account = givenUserAccountCreateDto().orElseThrow();
+            account = givenUserAccountRequestDto().orElseThrow();
         }
 
         @Test
@@ -202,7 +202,7 @@ public class AccountCreateDtoAnnotationTest{
 
         @BeforeEach
         void setUp(){
-            account = givenAdminAccountCreateDto().orElseThrow();
+            account = givenAdminAccountRequestDto().orElseThrow();
         }
 
         @Test


### PR DESCRIPTION
Change previous Account transactional entity implementations and adding the following:
- Replace AccountAdminResponseDto Role entity for newly created RoleResponseDto separating commitments
- AccountAdminResponseDto Person entity field replaced by PersonResponseDto
- Update respective Mappers to have according data conversion between objects
- Avoid Account mapper Overflow 
- Refactor not ideal conventions on AccountCreateDto usage for AccountRequestDto matching HTTP API backend development
### Sub-branches:
test/fix-rework-implementation
 