### PR TITLE
feature/person-delete

### DIFF
--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/controller/PersonController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/controller/PersonController.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -50,4 +51,13 @@ public class PersonController {
         if (responseDto.isPresent()) return ResponseEntity.ok(responseDto.orElseThrow());
         return ResponseEntity.notFound().build();
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<PersonResponseDto> delete(@PathVariable Long id){
+        Optional<PersonResponseDto> responseDto = personService.delete(id);
+        if(responseDto.isPresent()) return ResponseEntity.ok(responseDto.orElseThrow());
+        return ResponseEntity.notFound().build();
+    }
+
+
 }

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/entity/Person.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/entity/Person.java
@@ -2,6 +2,7 @@ package com.crhistianm.springboot.gallo.springboot_gallo.entity;
 
 import java.time.LocalDate;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -33,7 +34,7 @@ public class Person {
 
     private Double weight;
 
-    @OneToOne(mappedBy = "person")
+    @OneToOne(mappedBy = "person", cascade = CascadeType.REMOVE)
     private Account account;
 
     public Person(){

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/security/SpringSecurityConfig.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/security/SpringSecurityConfig.java
@@ -42,6 +42,7 @@ public class SpringSecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/api/persons").hasRole("ADMIN")
                 .requestMatchers(HttpMethod.GET, "/api/persons/{id}").hasRole("ADMIN")
                 .requestMatchers(HttpMethod.PUT, "/api/persons/{id}").hasRole("ADMIN")
+                .requestMatchers(HttpMethod.DELETE, "/api/persons/{id}").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.POST, "/api/persons/register").hasAnyRole("ADMIN", "USER")
                     .requestMatchers(HttpMethod.POST, "/api/accounts/register").hasAnyRole("ADMIN", "USER")
                     .requestMatchers("/swagger-ui/**").hasRole("ADMIN")

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/service/PersonService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/service/PersonService.java
@@ -12,6 +12,8 @@ public interface PersonService {
 
     Optional<PersonResponseDto> update(Long id, PersonRequestDto personDto);
 
+    Optional<PersonResponseDto> delete(Long id);
+
     boolean isPhoneNumberAvailable(String phoneNumber);
 
     boolean isPersonRegistered(Long personId);
@@ -19,6 +21,7 @@ public interface PersonService {
     List<PersonResponseDto> getAll();
 
     PersonResponseDto getById(Long id);
+
 
 }
 

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/service/PersonServiceImpl.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/service/PersonServiceImpl.java
@@ -42,6 +42,17 @@ public class PersonServiceImpl implements PersonService{
         return responseDto;
     }
 
+    @Transactional
+    @Override
+    public Optional<PersonResponseDto> delete(Long id) {
+        Optional<PersonResponseDto> responseDto =  Optional.empty();
+        Optional<Person> personOptional = personRepository.findById(id);
+        if(personOptional.isPresent()){
+            personRepository.delete(personOptional.orElseThrow());
+            responseDto = Optional.of(PersonMapper.entityToResponse(personOptional.orElseThrow()));
+        }
+        return responseDto;
+    }
 
     @Transactional(readOnly = true)
     @Override

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/controller/PersonControllerTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/controller/PersonControllerTest.java
@@ -2,6 +2,7 @@ package com.crhistianm.springboot.gallo.springboot_gallo.controller;
 
 import static org.mockito.Mockito.*;
 
+import org.aspectj.lang.annotation.Before;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -21,7 +22,6 @@ import java.util.Optional;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 
 import static com.crhistianm.springboot.gallo.springboot_gallo.data.Data.*;
-import static com.crhistianm.springboot.gallo.springboot_gallo.security.TokenJwtConfig.CONTENT_TYPE;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.config.JacksonConfig;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.PersonRequestDto;
@@ -31,7 +31,6 @@ import com.crhistianm.springboot.gallo.springboot_gallo.security.SpringSecurityC
 import com.crhistianm.springboot.gallo.springboot_gallo.service.PersonService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import ch.qos.logback.core.joran.conditional.ThenAction;
 import jakarta.validation.Validator;
 
 //Select controller class
@@ -138,6 +137,37 @@ public class PersonControllerTest {
         void testUpdateNotFound() throws Exception {
             mockMvc.perform(put("/api/persons/2")
                     .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(givenPersonRequestDtoTwo().orElseThrow())))
+                .andExpect(status().isNotFound());
+        }
+
+    }
+
+    @Nested
+    class DeleteModuleTest {
+        
+        @BeforeEach
+        void setUp(){
+            when(personService.delete(anyLong())).thenAnswer(invo -> {
+                Optional<PersonResponseDto> responseOptional = Optional.empty();
+                if(invo.getArgument(0, Long.class) == 1L) responseOptional = Optional.of(PersonMapper.entityToResponse(givenPersonEntityOne().orElseThrow()));
+                return responseOptional;
+            });
+        }
+
+        @Test
+        void testDelete() throws Exception {
+            mockMvc.perform(delete("/api/persons/1"))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.firstName").value("Crhistian"))
+                .andExpect(jsonPath("$.lastName").value("Mendez"))
+                .andExpect(jsonPath("$.phoneNumber").value("4444444"));
+        }
+
+        @Test
+        void testDeleteNotFound() throws Exception {
+            mockMvc.perform(delete("/api/persons/2"))
                 .andExpect(status().isNotFound());
         }
 

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/security/SpringEndpointSecurityTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/security/SpringEndpointSecurityTest.java
@@ -1,9 +1,10 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.security;
 
-import static com.crhistianm.springboot.gallo.springboot_gallo.security.TokenJwtConfig.CONTENT_TYPE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -123,6 +124,13 @@ public class SpringEndpointSecurityTest {
                 .andExpect(status().isNotFound());
         }
 
+        @Test
+        void testDeleteValidAuthority()throws Exception {
+            mockMvc.perform(delete("/api/person/1")
+                    .contentType(MediaType.APPLICATION_JSON).header("Authorization", prefixWithToken))
+                .andExpect(status().isNotFound());
+        }
+
     }
 
     @Nested
@@ -147,6 +155,13 @@ public class SpringEndpointSecurityTest {
         void testUpdateValidAuthority() throws Exception{
             mockMvc.perform(put("/api/persons/1")
                     .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(new PersonRequestDto())).header("Authorization", prefixWithToken))
+                .andExpect(status().isForbidden());
+        }
+
+        @Test
+        void testDeleteInvalidAuthority() throws Exception {
+            mockMvc.perform(delete("/api/persons/1")
+                    .header("Authorization", prefixWithToken))
                 .andExpect(status().isForbidden());
         }
 

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/service/PersonServiceImplUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/service/PersonServiceImplUnitTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.parameters.P;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.builder.PersonBuilder;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.PersonRequestDto;
@@ -179,6 +180,34 @@ public class PersonServiceImplUnitTest {
             assertFalse(isFound);
         }
         
+    }
+
+    @Nested
+    class DeleteModuleTest {
+
+        @BeforeEach
+        void setUp(){
+            when(personRepository.findById(anyLong())).thenAnswer(invo ->{
+                Optional<Person> personDb = Optional.empty();
+                if(invo.getArgument(0, Long.class) == 1L) personDb = givenPersonEntityOne();
+                return personDb;
+            });
+        }
+
+        @Test
+        void testDelete(){
+            Optional<PersonResponseDto> expectedResponse = Optional.of(PersonMapper.entityToResponse(givenPersonEntityOne().orElseThrow()));
+            assertEquals(expectedResponse, personServiceImpl.delete(1L));
+            verify(personRepository, times(1)).findById(anyLong());
+        }
+
+        @Test
+        void testDeleteEmpty(){
+            Optional<PersonResponseDto> expectedResponse = Optional.empty();
+            assertEquals(expectedResponse, personServiceImpl.delete(2L));
+            verify(personRepository, times(1)).findById(anyLong());
+        }
+
     }
 
 }


### PR DESCRIPTION
As the name convention explains it adds a Person deletion functionality including:
- Delete HTTP request method endpoint exposed to administrator authority
- Cascade type Delete on Person 1:1 Account bidirectional relationship to delete child dependent table data.
- Feature security, integration and service logic unit tests
### Sub-branches:
test/person-delete