### PR TITLE
feature/account-view

### DIFF
--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/controller/AccountController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/controller/AccountController.java
@@ -3,12 +3,15 @@ package com.crhistianm.springboot.gallo.springboot_gallo.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountRequestDto;
+import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.service.AccountService;
 
 import jakarta.validation.Valid;
@@ -23,6 +26,11 @@ public class AccountController {
     @PostMapping("/register")
     public ResponseEntity<?> create(@Valid @RequestBody AccountRequestDto accountDto){
         return ResponseEntity.status(HttpStatus.CREATED).body(accountService.save(accountDto));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<AccountResponseDto> viewById(@PathVariable Long id){
+        return ResponseEntity.ok(accountService.getById(id));
     }
 
 

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/controller/AccountController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/controller/AccountController.java
@@ -1,5 +1,7 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.controller;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountAdminResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountRequestDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.service.AccountService;
@@ -31,6 +34,11 @@ public class AccountController {
     @GetMapping("/{id}")
     public ResponseEntity<AccountResponseDto> viewById(@PathVariable Long id){
         return ResponseEntity.ok(accountService.getById(id));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<AccountAdminResponseDto>> viewAll(){
+        return ResponseEntity.ok(accountService.getAll());
     }
 
 

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/repository/AccountRepository.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/repository/AccountRepository.java
@@ -1,5 +1,6 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.Query;
@@ -18,5 +19,7 @@ public interface AccountRepository extends CrudRepository <Account, Long>{
 
     @Query("select a from Account a where a.person.id=?1")
     Optional<Account> findAccountByPersonId(Long personId);
+
+    List<Account> findAll();
 
 }

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/security/SpringSecurityConfig.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/security/SpringSecurityConfig.java
@@ -49,6 +49,7 @@ public class SpringSecurityConfig {
                 .requestMatchers(HttpMethod.DELETE, "/api/persons/{id}").hasAnyRole("ADMIN", "USER")
                     .requestMatchers(HttpMethod.POST, "/api/persons/register").hasAnyRole("ADMIN", "USER")
                     .requestMatchers(HttpMethod.POST, "/api/accounts/register").hasAnyRole("ADMIN", "USER")
+                    .requestMatchers(HttpMethod.GET, "/api/accounts/{id}").hasAnyRole("ADMIN", "USER")
                     .requestMatchers("/swagger-ui/**").hasRole("ADMIN")
                     .requestMatchers("/v3/**").hasRole("ADMIN")
                     .anyRequest().authenticated())

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/security/SpringSecurityConfig.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/security/SpringSecurityConfig.java
@@ -50,6 +50,7 @@ public class SpringSecurityConfig {
                     .requestMatchers(HttpMethod.POST, "/api/persons/register").hasAnyRole("ADMIN", "USER")
                     .requestMatchers(HttpMethod.POST, "/api/accounts/register").hasAnyRole("ADMIN", "USER")
                     .requestMatchers(HttpMethod.GET, "/api/accounts/{id}").hasAnyRole("ADMIN", "USER")
+                    .requestMatchers(HttpMethod.GET, "/api/accounts").hasAnyRole("ADMIN")
                     .requestMatchers("/swagger-ui/**").hasRole("ADMIN")
                     .requestMatchers("/v3/**").hasRole("ADMIN")
                     .anyRequest().authenticated())

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/service/AccountService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/service/AccountService.java
@@ -3,10 +3,15 @@ package com.crhistianm.springboot.gallo.springboot_gallo.service;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountRequestDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountResponseDto;
+import com.crhistianm.springboot.gallo.springboot_gallo.entity.Account;
 
 public interface AccountService {
 
+    AccountResponseDto settleResponseType(Account account);
+
     AccountResponseDto save(AccountRequestDto accountDto);
+
+    AccountResponseDto getById(Long id);
     
     boolean isEmailAvailable(String email);
 

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/service/AccountService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/service/AccountService.java
@@ -1,6 +1,9 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.service;
 
 
+import java.util.List;
+
+import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountAdminResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountRequestDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.entity.Account;
@@ -12,6 +15,8 @@ public interface AccountService {
     AccountResponseDto save(AccountRequestDto accountDto);
 
     AccountResponseDto getById(Long id);
+
+    List<AccountAdminResponseDto> getAll();
     
     boolean isEmailAvailable(String email);
 

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/service/AccountServiceImpl.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/service/AccountServiceImpl.java
@@ -3,12 +3,15 @@ package com.crhistianm.springboot.gallo.springboot_gallo.service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountAdminResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountRequestDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.dto.AccountResponseDto;
 import com.crhistianm.springboot.gallo.springboot_gallo.entity.Account;
@@ -77,6 +80,13 @@ public class AccountServiceImpl implements AccountService{
     public AccountResponseDto getById(Long id) {
         Account account = accountRepository.findById(id).orElseThrow(() -> new NotFoundException(Account.class));
         return settleResponseType(account);
+    }
+
+    @Override
+    @Transactional
+    public List<AccountAdminResponseDto> getAll() {
+        List<AccountAdminResponseDto> accountList = accountRepository.findAll().stream().map(a -> (AccountAdminResponseDto) AccountMapper.entityToAdminResponse(a)).collect(Collectors.toList());
+        return accountList;
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/controller/AccountControllerTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/controller/AccountControllerTest.java
@@ -14,6 +14,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 
 import static com.crhistianm.springboot.gallo.springboot_gallo.data.Data.*;
@@ -91,6 +94,17 @@ public class AccountControllerTest {
                 if(invo.getArgument(0, Long.class) == 1L) return AccountMapper.entityToAdminResponse(givenAccountEntityAdmin().orElseThrow());
                 return AccountMapper.entityToResponse(givenAccountEntityUser().orElseThrow());
             });
+        }
+
+        @Test
+        void testViewAll() throws Exception {
+            when(accountService.getAll()).thenReturn(List.of((AccountAdminResponseDto)AccountMapper.entityToAdminResponse(givenAccountEntityAdmin().orElseThrow()), 
+                    (AccountAdminResponseDto)AccountMapper.entityToAdminResponse(givenAccountEntityUser().orElseThrow())));
+            mockMvc.perform(get("/api/accounts"))
+                .andExpect(jsonPath("$[0].id").value(1L))
+                .andExpect(jsonPath("$[1].id").value(1L))
+                .andExpect(jsonPath("$[0].email").value("admin@gmail.com"))
+                .andExpect(jsonPath("$[1].email").value("user@gmail.com"));
         }
 
         @Test

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/security/SpringEndpointSecurityTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/security/SpringEndpointSecurityTest.java
@@ -135,6 +135,14 @@ public class SpringEndpointSecurityTest {
                     .andExpect(status().isBadRequest());
             }
 
+            @Test
+            void testViewByIdValidAuthority() throws Exception {
+                mockMvc.perform(get("/api/accounts/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", prefixWithToken))
+                    .andExpect(status().isNotFound());
+            }
+
         }
         
         @Nested
@@ -205,6 +213,14 @@ public class SpringEndpointSecurityTest {
                 mockMvc.perform(post("/api/accounts/register")
                         .header("Authorization", prefixWithToken))
                     .andExpect(status().isBadRequest());
+            }
+
+            @Test
+            void testViewByIdValidAuthority() throws Exception {
+                mockMvc.perform(get("/api/accounts/2")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", prefixWithToken))
+                    .andExpect(status().isNotFound());
             }
 
         }

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/security/SpringEndpointSecurityTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/security/SpringEndpointSecurityTest.java
@@ -143,6 +143,13 @@ public class SpringEndpointSecurityTest {
                     .andExpect(status().isNotFound());
             }
 
+            @Test
+            void testViewAllValidAuthority() throws Exception {
+                mockMvc.perform(get("/api/accounts")
+                        .header("Authorization", prefixWithToken))
+                    .andExpect(status().isOk());
+            }
+
         }
         
         @Nested
@@ -221,6 +228,13 @@ public class SpringEndpointSecurityTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", prefixWithToken))
                     .andExpect(status().isNotFound());
+            }
+
+            @Test
+            void testViewAllInvalidAuthority() throws Exception {
+                mockMvc.perform(get("/api/accounts")
+                        .header("Authorization", prefixWithToken))
+                    .andExpect(status().isForbidden());
             }
 
         }

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/service/AccountServiceImplUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/service/AccountServiceImplUnitTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -78,11 +79,20 @@ class AccountServiceImplUnitTest {
 
         @BeforeEach
         void setUp(){
-            when(accountRepository.findById(anyLong())).thenAnswer(invo -> {
+            lenient().when(accountRepository.findById(anyLong())).thenAnswer(invo -> {
                 Optional<Account> accountOptional = Optional.empty();
                 if(invo.getArgument(0, Long.class) == 1L) accountOptional = givenAccountEntityAdmin();
                 return accountOptional;
             });
+        }
+
+        @Test
+        void testGetAll(){
+            when(accountRepository.findAll()).thenReturn(List.of(givenAccountEntityAdmin().orElseThrow(), givenAccountEntityUser().orElseThrow()));
+            List<AccountAdminResponseDto> expectedList = List.of((AccountAdminResponseDto)AccountMapper.entityToAdminResponse(givenAccountEntityAdmin().orElseThrow()), 
+                    (AccountAdminResponseDto)AccountMapper.entityToAdminResponse(givenAccountEntityUser().orElseThrow()));
+            assertEquals(expectedList, accountServiceImpl.getAll());
+            verify(accountRepository, times(1)).findAll();
         }
 
         @Test

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/service/AccountServiceImplUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/service/AccountServiceImplUnitTest.java
@@ -96,7 +96,7 @@ class AccountServiceImplUnitTest {
         }
 
         @Test
-        void testViewByIdNotFound(){
+        void testgetByIdNotFound(){
             assertThrows(NotFoundException.class, () -> {
                 accountServiceImpl.getById(2L);
             });
@@ -104,7 +104,7 @@ class AccountServiceImplUnitTest {
         }
 
         @Test
-        void testViewById(){
+        void testGetById(){
             assertEquals("admin@gmail.com", accountServiceImpl.getById(1L).getEmail());
             verify(accountRepository, times(1)).findById(anyLong());
         }


### PR DESCRIPTION
This feature provides both viewing accounts through respective endpoints. Can be retrieved by id for both authorities or a List of all accounts available(admin authority). Includes for each implementation:
- Implementation service unit tests
- WebMvc tests
- Endpoint security tests
### Sub-branches:
feature/account-view-by-id
test/account-view-by-id
feature/account-view-all
test/account-view-all