### PR TITLE
Add missing JPA entity specifications

### DIFF
--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/Account.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/Account.java
@@ -31,23 +31,25 @@ public class Account {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true)
+    @Column(unique = true, nullable = false, length = 100)
     private String email;
 
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Column(nullable = false, length = 150)
     private String password;
 
     @Embedded
     private Audit audit = new Audit();
 
     @OneToOne(cascade = CascadeType.REMOVE)
+    @JoinColumn(nullable = false, unique = true)
     private Person person;
 
     @ManyToMany
     @JoinTable(
         name = "account_role",
-        joinColumns = @JoinColumn(name = "account_id"),
-        inverseJoinColumns = @JoinColumn(name = "role_id"),
+        joinColumns = @JoinColumn(name = "account_id", nullable = false),
+        inverseJoinColumns = @JoinColumn(name = "role_id", nullable = false),
         uniqueConstraints = {@UniqueConstraint(columnNames = {"account_id", "role_id"})}
     )
     private List<Role> roles;

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/Audit.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/Audit.java
@@ -2,6 +2,9 @@ package com.crhistianm.springboot.gallo.springboot_gallo.account;
 
 import java.time.LocalDateTime;
 
+import org.hibernate.annotations.ColumnDefault;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
@@ -9,10 +12,14 @@ import jakarta.persistence.PreUpdate;
 @Embeddable
 class Audit {
 
+    @Column(nullable = false)
     private LocalDateTime createdAt;
 
+    @Column(nullable = true)
     private LocalDateTime updatedAt;
 
+    @Column(nullable = false)
+    @ColumnDefault(value = "true")
     private boolean enabled;
 
     @PrePersist

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/Role.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/Role.java
@@ -19,7 +19,7 @@ public class Role {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true)
+    @Column(unique = true, length = 45)
     private String name;
 
     //Created inverse relationship as i need to query how many users have roles 

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPart.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPart.java
@@ -15,7 +15,7 @@ public class BodyPart {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true)
+    @Column(unique = true, length = 45, nullable = false)
     private String name;
 
     BodyPart() {

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/Exercise.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/Exercise.java
@@ -4,7 +4,11 @@ package com.crhistianm.springboot.gallo.springboot_gallo.exercise;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.ColumnDefault;
+
 import com.crhistianm.springboot.gallo.springboot_gallo.bodypart.BodyPart;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -24,20 +28,25 @@ public class Exercise {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, length = 60)
     private String name;
 
+    @Column(nullable = true, length = 200)
     private String description;
 
+    @Column(nullable = false)
+    @ColumnDefault(value = "false")
     private Boolean weightRequired;
 
+    @Column(nullable = true, length = 255)
     private String imageUrl;
 
     //Not bidirectional as i only expect to need bodyparts of a exercise, not inverse
     @ManyToMany
     @JoinTable(
         name = "exercise_body_part",
-        joinColumns = @JoinColumn (name = "exercise_id"),
-        inverseJoinColumns = @JoinColumn(name = "body_part_id"),
+        joinColumns = @JoinColumn (name = "exercise_id", nullable = false),
+        inverseJoinColumns = @JoinColumn(name = "body_part_id", nullable = false),
         uniqueConstraints = {@UniqueConstraint(columnNames = {"exercise_id", "body_part_id"})}
     )
     private List<BodyPart> bodyParts;

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/Person.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/Person.java
@@ -2,6 +2,8 @@ package com.crhistianm.springboot.gallo.springboot_gallo.person;
 
 import java.time.LocalDate;
 
+import org.hibernate.annotations.Check;
+
 import com.crhistianm.springboot.gallo.springboot_gallo.account.Account;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -20,19 +22,28 @@ public class Person {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, length = 45)
     private String firstName;
 
+    @Column(nullable = false, length = 45)
     private String lastName;
 
-    @Column(unique = true)
+    @Column(unique = true, nullable = false, length = 16)
     private String phoneNumber;
 
+    @Column(nullable = false)
     private LocalDate birthDate;
 
+    @Column(nullable = false, length = 2)
+    @Check(constraints = "gender IN ('M', 'F', 'NT')")
     private String gender;
 
+    @Column(nullable = true, precision = 3)
+    @Check(constraints = "height >= 0.50 AND height <= 3.00")
     private Double height;
 
+    @Column(nullable = true, precision = 4)
+    @Check(constraints = "weight >= 020.0 AND weight <= 200.0")
     private Double weight;
 
     @OneToOne(mappedBy = "person", cascade = CascadeType.REMOVE)

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/refreshtoken/RefreshToken.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/refreshtoken/RefreshToken.java
@@ -2,6 +2,8 @@ package com.crhistianm.springboot.gallo.springboot_gallo.refreshtoken;
 
 import java.time.LocalDateTime;
 
+import org.hibernate.annotations.ColumnDefault;
+
 import com.crhistianm.springboot.gallo.springboot_gallo.account.Account;
 
 import jakarta.persistence.Column;
@@ -28,6 +30,7 @@ public class RefreshToken {
     private LocalDateTime expiresAt;
 
     @Column(nullable = false)
+    @ColumnDefault(value = "false")
     private Boolean revoked;
 
     @ManyToOne

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workout/Workout.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workout/Workout.java
@@ -8,10 +8,12 @@ import com.crhistianm.springboot.gallo.springboot_gallo.account.Account;
 import com.crhistianm.springboot.gallo.springboot_gallo.exercise.Exercise;
 import com.crhistianm.springboot.gallo.springboot_gallo.workoutset.WorkoutSet;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -24,16 +26,20 @@ public class Workout {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private LocalDate workoutDate;
 
+    @Column(nullable = true)
     private short workoutLength;
 
     //This relationship is not bidirectional 
     @ManyToOne
+    @JoinColumn(nullable = false)
     private Exercise exercise;
 
     //bidirectional
     @ManyToOne
+    @JoinColumn(nullable = false)
     private Account account;
 
     @OneToMany(mappedBy = "workout")

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSet.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSet.java
@@ -1,11 +1,15 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.workoutset;
 
+import org.hibernate.annotations.ColumnDefault;
+
 import com.crhistianm.springboot.gallo.springboot_gallo.workout.Workout;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
@@ -17,14 +21,19 @@ public class WorkoutSet {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, precision = 2)
     private Byte repAmount;
 
+    @Column(nullable = false, precision = 5)
     private Double weightAmount;
 
+    @Column(nullable = false)
+    @ColumnDefault(value = "false")
     private Boolean toFailure;
 
     //Bidirectional
     @ManyToOne
+    @JoinColumn(nullable = false)
     private Workout workout;
 
     WorkoutSet(){

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountRepositoryTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountRepositoryTest.java
@@ -34,7 +34,12 @@ class AccountRepositoryTest {
         Person person = getPersonInstance();
         person.setFirstName("two");
         person.setId(1L);
-        Account account = new AccountBuilder().email("example@gmail.com").person(person).build();
+
+        Account account = new AccountBuilder()
+            .email("example@gmail.com")
+            .password("password")
+            .person(person).build();
+
         accountRepository.save(account);
 
         assertTrue(accountRepository.findByEmail("example@gmail.com").isPresent());

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountTest.java
@@ -30,8 +30,7 @@ class AccountTest {
     @DisplayName("Testing per persists createdAt Date")
     @Sql(scripts = "classpath:personinserts.sql")
     void testLifeCyclePersist(){
-        Person person = getPersonInstance();
-        person.setFirstName("example");
+        Person person = entityManager.getReference(Person.class, 1L);
         Account account = new AccountBuilder().email("example@gmail.com").password("12345").person(person).build();
         boolean result = false;
         Account accountResult = accountRepository.save(account);


### PR DESCRIPTION
This PR matches curret gallo SQL [script] table entities specifications.


[script]: https://github.com/CrhistianMRe/gallo-backend/blob/main/backend/src/main/resources/gallo.sql
