### PR TITLE
Add proper response DTO to access token refresh endpoint

### DIFF
--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/refreshtoken/RefreshTokenController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/refreshtoken/RefreshTokenController.java
@@ -1,7 +1,5 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.refreshtoken;
 
-import java.util.Map;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,7 +22,7 @@ class RefreshTokenController {
 
     @SecurityRequirements(value = {})
     @PostMapping
-    ResponseEntity<Map<String, String>> generateNewToken(@Valid @RequestBody RefreshTokenRequestDto requestDto) {
+    ResponseEntity<RefreshTokenResponseDto> generateNewToken(@Valid @RequestBody RefreshTokenRequestDto requestDto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(refreshTokenService.refreshAccessToken(requestDto));
     }
 

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/refreshtoken/RefreshTokenResponseDto.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/refreshtoken/RefreshTokenResponseDto.java
@@ -1,0 +1,68 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.refreshtoken;
+
+class RefreshTokenResponseDto {
+
+    private String accessToken;
+
+    private String expiresAt;
+
+    RefreshTokenResponseDto(){}
+
+    RefreshTokenResponseDto(String accessToken, String expiresAt) {
+        this.accessToken = accessToken;
+        this.expiresAt = expiresAt;
+    }
+
+    String getAccessToken() {
+        return accessToken;
+    }
+
+    void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    String getExpiresAt() {
+        return expiresAt;
+    }
+
+    void setExpiresAt(String expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((accessToken == null) ? 0 : accessToken.hashCode());
+        result = prime * result + ((expiresAt == null) ? 0 : expiresAt.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        RefreshTokenResponseDto other = (RefreshTokenResponseDto) obj;
+        if (accessToken == null) {
+            if (other.accessToken != null)
+                return false;
+        } else if (!accessToken.equals(other.accessToken))
+            return false;
+        if (expiresAt == null) {
+            if (other.expiresAt != null)
+                return false;
+        } else if (!expiresAt.equals(other.expiresAt))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "RefreshTokenResponseDto [accessToken=" + accessToken + ", expiresAt=" + expiresAt + "]";
+    }
+    
+}

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/refreshtoken/RefreshTokenService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/refreshtoken/RefreshTokenService.java
@@ -3,8 +3,6 @@ package com.crhistianm.springboot.gallo.springboot_gallo.refreshtoken;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -43,7 +41,7 @@ public class RefreshTokenService {
         }
 
     @Transactional(readOnly = true)
-    Map<String, String> refreshAccessToken(final RefreshTokenRequestDto requestDto) {
+    RefreshTokenResponseDto refreshAccessToken(final RefreshTokenRequestDto requestDto) {
         final String refreshToken = requestDto.getRefreshToken();
 
         refreshTokenValidator.validateTokenRefresh(refreshToken);
@@ -73,12 +71,12 @@ public class RefreshTokenService {
 
         final String accessToken = JwtUtils.createAccessJwt(email, claims, expiresAt);
 
-        Map<String, String> response = new HashMap<>();
+        RefreshTokenResponseDto responseDto = new RefreshTokenResponseDto();
 
-        response.put("accessToken", accessToken);
-        response.put("expiresAt", expiresAt.toInstant().toString());
+        responseDto.setAccessToken(accessToken);
+        responseDto.setExpiresAt(expiresAt.toInstant().toString());
 
-        return response;
+        return responseDto;
     }
 
     @Transactional

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/refreshtoken/RefreshTokenControllerTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/refreshtoken/RefreshTokenControllerTest.java
@@ -41,11 +41,11 @@ class RefreshTokenControllerTest {
     @BeforeEach
     void setUp() {
         doAnswer(invo -> {
-            Map<String, String> responseMap = new HashMap<>();
+            RefreshTokenResponseDto responseDto = new RefreshTokenResponseDto();
 
-            responseMap.put("accessToken", "valid");
+            responseDto.setAccessToken("valid");
 
-            return responseMap;
+            return responseDto;
         }).when(refreshTokenService).refreshAccessToken(any(RefreshTokenRequestDto.class));
 
     }

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/refreshtoken/RefreshTokenServiceUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/refreshtoken/RefreshTokenServiceUnitTest.java
@@ -100,10 +100,10 @@ class RefreshTokenServiceUnitTest {
 
         @Test
         void shouldReturnValidRefreshToken() {
-            Map<String, String> responseMap  = refreshTokenService.refreshAccessToken(requestDto);
+            RefreshTokenResponseDto responseDto = refreshTokenService.refreshAccessToken(requestDto);
 
-            assertThat(responseMap).extractingByKey("accessToken").asString().startsWith("eyJ");
-            assertThat(responseMap).extractingByKey("expiresAt").asString().isNotEmpty();
+            assertThat(responseDto).extracting(RefreshTokenResponseDto::getAccessToken).asString().startsWith("eyJ");
+            assertThat(responseDto).extracting(RefreshTokenResponseDto::getExpiresAt).asString().isNotEmpty();
 
             verify(refreshTokenRepository, times(1)).findByToken(requestDto.getRefreshToken());
         }


### PR DESCRIPTION
This PR replaces previous response implementation for access token refresh.

## Endpoint affected: POST `api/auth/refresh`

### Solved: 

Resolves #185

>[!NOTE]
>This issue was fixed to match OpenAPI response requirement for documenting endpoint
