### PR TITLE
Reduce not found response modules ambuigity

### DIFF
--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workout/WorkoutService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workout/WorkoutService.java
@@ -8,10 +8,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.account.Account;
 import com.crhistianm.springboot.gallo.springboot_gallo.exercise.Exercise;
-import com.crhistianm.springboot.gallo.springboot_gallo.shared.exception.NotFoundException;
 
 import jakarta.persistence.EntityManager;
-
 
 @Service
 class WorkoutService {
@@ -30,7 +28,6 @@ class WorkoutService {
 
     @Transactional(readOnly = true)
     PagedModel<WorkoutResponseDto> getByAccountId(Long accountId, int page, int size) {
-        if(!workoutRepository.existsByAccountId(accountId)) throw new NotFoundException(Workout.class);
         workoutValidator.validateByIdRequest(accountId);
         Page<WorkoutResponseDto> responsePage = workoutRepository.findByAccountId(accountId, PageRequest.of(page, size))
             .map(WorkoutMapper::entityToResponse);

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workout/WorkoutValidator.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workout/WorkoutValidator.java
@@ -36,9 +36,13 @@ class WorkoutValidator {
         }
 
     void validateByIdRequest(Long accountId) {
-        identityService.validateAllowanceByAccountId(accountId).ifPresent(f -> {
-            throw new ValidationServiceException(List.of(f));
-        });
+        List<FieldInfoError> errorList = new ArrayList<>();
+
+        accountService.validateAccountRegistered(accountId).ifPresent(errorList::add);
+        identityService.validateAllowanceByAccountId(accountId).ifPresent(errorList::add);
+
+            //Aqui te quedaste tenes que verificar sin tirar el 404 en las que son ambiguas como esta
+        if(!errorList.isEmpty()) throw new ValidationServiceException(errorList);
     }
 
     void validateRequest(WorkoutRequestDto requestDto) {

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/security/SpringEndpointSecurityTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/security/SpringEndpointSecurityTest.java
@@ -234,10 +234,10 @@ class SpringEndpointSecurityTest {
         class Workout {
 
             @Test
-            void shouldReturnNotFoundStatusWhenViewPageGetRequestIsSent() throws Exception {
+            void shouldReturnBadRequestStatusWhenViewPageGetRequestIsSent() throws Exception {
                 mockMvc.perform(get("/api/workouts/1?page=0&size=4")
                         .header("Authorization", prefixWithToken))
-                    .andExpect(status().isNotFound());
+                    .andExpect(status().isBadRequest());
             }
 
             @Test
@@ -358,10 +358,10 @@ class SpringEndpointSecurityTest {
         class Workout {
 
             @Test
-            void shouldReturnNotFoundStatusWhenViewPageGetRequestIsSent() throws Exception {
+            void shouldReturnBadRequestStatusWhenViewPageGetRequestIsSent() throws Exception {
                 mockMvc.perform(get("/api/workouts/1?page=0&size=4")
                         .header("Authorization", prefixWithToken))
-                    .andExpect(status().isNotFound());
+                    .andExpect(status().isBadRequest());
             }
 
             @Test

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/workout/WorkoutServiceUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/workout/WorkoutServiceUnitTest.java
@@ -64,11 +64,6 @@ class WorkoutServiceUnitTest {
         void setUp() {
             accountId = null;
 
-            doAnswer(invo ->{
-                Long argAccountId = invo.getArgument(0, Long.class);
-                return !argAccountId.equals(99L);
-            }).when(workoutRepository).existsByAccountId(anyLong());
-
             lenient().doAnswer(invo -> {
                 if(!invo.getArgument(0, Long.class).equals(1L)) throw new ValidationServiceException();
                 return null;
@@ -108,7 +103,6 @@ class WorkoutServiceUnitTest {
             assertThat(listResponse).extracting(WorkoutResponseDto::getWorkoutDate).contains(LocalDate.of(2000, 01, 01)).hasSize(4);
 
             verify(workoutValidator, times(1)).validateByIdRequest(eq(accountId));
-            verify(workoutRepository, times(1)).existsByAccountId(eq(accountId));
             verify(workoutRepository, times(1)).findByAccountId(eq(accountId), eq(PageRequest.of(0, 1)));
         }
 
@@ -117,23 +111,8 @@ class WorkoutServiceUnitTest {
             accountId = 2L;
             assertThatExceptionOfType(Exception.class).isThrownBy(() -> workoutService.getByAccountId(accountId, 0, 1));
 
-            verify(workoutRepository, times(1)).existsByAccountId(accountId);
-            verifyNoMoreInteractions(workoutRepository);
             verify(workoutValidator, times(1)).validateByIdRequest(eq(accountId));
-        }
-
-        @Test
-        void shouldThrowNotFoundException() {
-            accountId = 99L;
-            String message = assertThatExceptionOfType(NotFoundException.class)
-                .isThrownBy(() -> workoutService.getByAccountId(accountId, 0, 1))
-                .actual().getMessage();
-
-            assertThat(message).isEqualTo("Workout not found");
-
-            verify(workoutRepository, times(1)).existsByAccountId(eq(accountId));
-            verifyNoMoreInteractions(workoutRepository);
-            verifyNoInteractions(workoutValidator);
+            verifyNoInteractions(workoutRepository);
         }
 
     } 


### PR DESCRIPTION
This PR reduces ambiguity by removing workout module 404 NOT FOUND handling.

### Explanation:

Both **Person**, **Account**, and **Refresh Token** modules have HTTP 404 NOT found handling as they use their own ID in the path.

Workout and WorkoutSet module do not use their own IDs not found or existence will be managed by validation service(400) bad request response.

#### Examples:

- `api/accounts/{account ID}`

- `api/persons/{person ID}`

While:

- `api/workouts/{account ID}` not `api/workouts/{workout ID}`

- `api/workouts-sets/{workout ID}` not `api/workout-sets/{workout set ID}`


