### PR TITLE
Delegate workout sub-modules not found responses to main validators

### DIFF
--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/IdentityVerificationService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/IdentityVerificationService.java
@@ -10,13 +10,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.shared.FieldInfoErrorBuilder;
 import com.crhistianm.springboot.gallo.springboot_gallo.shared.RequestDto;
-import com.crhistianm.springboot.gallo.springboot_gallo.person.Person;
-import com.crhistianm.springboot.gallo.springboot_gallo.shared.exception.NotFoundException;
 import com.crhistianm.springboot.gallo.springboot_gallo.shared.FieldInfoErrorMapper;
 import com.crhistianm.springboot.gallo.springboot_gallo.shared.FieldInfoError;
 import com.crhistianm.springboot.gallo.springboot_gallo.shared.security.CustomAccountUserDetails;
-import com.crhistianm.springboot.gallo.springboot_gallo.workout.Workout;
-
 
 @Service
 public class IdentityVerificationService {
@@ -46,7 +42,7 @@ public class IdentityVerificationService {
     public Optional<FieldInfoError> validateUserAllowanceByPersonId(Long personId) {
         if(personId == null) return Optional.empty();
         FieldInfoError infoError = null;
-        Long accountId = accountRepository.findAccountByPersonId(personId).orElseThrow(() -> new NotFoundException(Account.class)).getId();
+        Long accountId = accountRepository.findAccountByPersonId(personId).orElseThrow().getId();
         if(!isUserAllowed(accountId)){
             infoError = new FieldInfoErrorBuilder()
                     .name("path id")
@@ -76,7 +72,7 @@ public class IdentityVerificationService {
         FieldInfoError infoError  = null;
 
         Long accountId = accountRepository.findAccountByWorkoutId(workoutId)
-            .orElseThrow(() -> new NotFoundException(Workout.class)).getId();
+            .orElseThrow().getId();
 
         if(!isUserAllowed(accountId)) {
             infoError =  new FieldInfoErrorBuilder()

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workout/WorkoutValidator.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workout/WorkoutValidator.java
@@ -39,7 +39,11 @@ class WorkoutValidator {
     void validateByIdRequest(Long accountId) {
         ValidationServiceErrorList errorList = new ValidationServiceErrorList();
 
-        accountService.validateAccountRegistered(accountId).ifPresent(errorList::add);
+        accountService.validateAccountRegistered(accountId).ifPresent(error -> {
+            errorList.add(error);
+            errorList.throwFieldErrors();
+        });
+
         identityService.validateAllowanceByAccountId(accountId).ifPresent(errorList::add);
 
         errorList.throwFieldErrors();
@@ -48,8 +52,15 @@ class WorkoutValidator {
     void validateRequest(WorkoutRequestDto requestDto) {
         ValidationServiceErrorList errorList = new ValidationServiceErrorList();
 
-        accountService.validateAccountRegistered(requestDto.getAccountId()).ifPresent(errorList::add);
-        exerciseService.validateExerciseExistence(requestDto.getExerciseId()).ifPresent(errorList::add);
+        accountService.validateAccountRegistered(requestDto.getAccountId()).ifPresent(error -> {
+            errorList.add(error);
+            errorList.throwFieldErrors();
+        });
+
+        exerciseService.validateExerciseExistence(requestDto.getExerciseId()).ifPresent(error -> {
+            errorList.add(error);
+            errorList.throwFieldErrors();
+        });
 
         identityService.validateAllowanceByAccountId(requestDto.getAccountId()).ifPresent(errorList::add);
 

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetValidator.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetValidator.java
@@ -29,7 +29,10 @@ class WorkoutSetValidator {
     void validateSaveAllRequest(WorkoutSetRequestDto requestDto) {
         ValidationServiceErrorList errorFields = new ValidationServiceErrorList();
 
-        workoutValidationService.validateWorkoutExistence(requestDto.getWorkoutId()).ifPresent(errorFields::add);
+        workoutValidationService.validateWorkoutExistence(requestDto.getWorkoutId()).ifPresent(error -> {
+            errorFields.add(error);
+            errorFields.throwFieldErrors();
+        });
 
         identityVerificationService.validateUserAllowanceByWorkoutId(requestDto.getWorkoutId()).ifPresent(errorFields::add);
 

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/account/IdentityVerificationServiceUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/account/IdentityVerificationServiceUnitTest.java
@@ -152,22 +152,6 @@ class IdentityVerificationServiceUnitTest {
         }
 
         @Test
-        void shouldThrowExceptionWhenPersonIdIsNotFound() {
-            String errorMessage = assertThatExceptionOfType(NotFoundException.class).
-                isThrownBy(() -> spyServiceIdentity.validateUserAllowanceByPersonId(20L))
-                .actual()
-                .getMessage();
-
-            assertThat(errorMessage).isEqualTo("Account not found");
-
-
-            verify(accountRepository).findAccountByPersonId(eq(20L));
-            verify(spyServiceIdentity, times(0)).isUserAllowed(anyLong());
-            verifyNoInteractions(environment);
-        }
-
-
-        @Test
         void shouldReturnEmptyOptionalWhenUserIsAllowed(){
             fieldOptional = spyServiceIdentity.validateUserAllowanceByPersonId(2L);
 
@@ -374,22 +358,6 @@ class IdentityVerificationServiceUnitTest {
 
             verify(accountRepository, times(1)).findAccountByWorkoutId(eq(workoutId));
             verify(spyServiceIdentity, times(1)).isUserAllowed(eq(1L));
-            verifyNoInteractions(environment);
-        }
-
-        @Test
-        void shouldThrowExceptionWhenWorkoutIdIsNotFound() {
-            workoutId = 3L;
-
-            String expectedMessage = assertThatExceptionOfType(NotFoundException.class)
-                .isThrownBy(() -> spyServiceIdentity.validateUserAllowanceByWorkoutId(workoutId))
-                .actual()
-                .getMessage();
-
-            assertThat(expectedMessage).isEqualTo("Workout not found");
-
-            verify(accountRepository, times(1)).findAccountByWorkoutId(eq(workoutId));
-            verify(spyServiceIdentity, times(0)).isUserAllowed(anyLong());
             verifyNoInteractions(environment);
         }
 

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/workout/WorkoutValidatorUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/workout/WorkoutValidatorUnitTest.java
@@ -8,8 +8,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -51,34 +53,68 @@ class WorkoutValidatorUnitTest {
     private WorkoutValidator workoutValidator;
 
     @Nested
-    class ViewModule {
+    class ValidateByIdRequestMethodTest {
 
         Long accountId;
 
         @BeforeEach
         void setUp() {
             accountId = null;
-            doAnswer(invo -> {
-                FieldInfoError errorOptional = null;
-                if(invo.getArgument(0, Long.class).equals(2L)) {
-                    errorOptional = new FieldInfoErrorBuilder().name("error").build();
+            lenient().doAnswer(invo -> {
+                FieldInfoError fieldError = null;
+
+                final Long argAccountId = invo.getArgument(0, Long.class);
+
+                if(!argAccountId.equals(1L)) {
+                    fieldError = new FieldInfoErrorBuilder().name("allowance").build();
                 }
-                return Optional.ofNullable(errorOptional);
+                return Optional.ofNullable(fieldError);
             }).when(identityVerificationService).validateAllowanceByAccountId(anyLong());
+
+            doAnswer(invo ->{
+                FieldInfoError fieldError = null;
+
+                final Long argAccountId = invo.getArgument(0, Long.class);
+
+                if(argAccountId.equals(2L)) fieldError = new FieldInfoErrorBuilder().name("registered").build();
+
+                return Optional.ofNullable(fieldError);
+            }).when(accountService).validateAccountRegistered(anyLong());
 
         }
 
         @Test
-        void shouldThrowValidationExceptionWhenUserIsNotAllowed() {
+        void shouldThrowValidationExceptionWithOnlyAccountRegisteredError() {
             accountId = 2L;
 
-            String errorName = assertThatExceptionOfType(ValidationServiceException.class)
+            final List<FieldInfoError> errorList = assertThatExceptionOfType(ValidationServiceException.class)
                 .isThrownBy(() -> workoutValidator.validateByIdRequest(accountId))
-                .actual().getFieldErrors().get(0).getName();
+                .actual()
+                .getFieldErrors();
 
-            assertThat(errorName).isEqualTo("error");
+            assertThat(errorList).hasSize(1);
 
-            verify(identityVerificationService).validateAllowanceByAccountId(accountId);
+            assertThat(errorList).extracting(FieldInfoError::getName).containsOnlyOnce("registered");
+                
+            verify(accountService, times(1)).validateAccountRegistered(eq(accountId));
+            verifyNoInteractions(identityVerificationService);
+        }
+
+        @Test
+        void shouldThrowValidationExceptionWithOnlyInvalidAllowanceError() {
+            accountId = 3L;
+
+            final List<FieldInfoError> errorList = assertThatExceptionOfType(ValidationServiceException.class)
+                .isThrownBy(() -> workoutValidator.validateByIdRequest(accountId))
+                .actual()
+                .getFieldErrors();
+
+            assertThat(errorList).hasSize(1);
+
+            assertThat(errorList).extracting(FieldInfoError::getName).containsOnlyOnce("allowance");
+
+            verify(accountService, times(1)).validateAccountRegistered(eq(accountId));
+            verify(identityVerificationService, times(1)).validateAllowanceByAccountId(eq(accountId));
         }
 
         @Test
@@ -86,7 +122,9 @@ class WorkoutValidatorUnitTest {
             accountId = 1L;
             assertDoesNotThrow(() -> workoutValidator.validateByIdRequest(accountId));
 
-            verify(identityVerificationService).validateAllowanceByAccountId(accountId);
+
+            verify(accountService, times(1)).validateAccountRegistered(eq(accountId));
+            verify(identityVerificationService, times(1)).validateAllowanceByAccountId(eq(accountId));
         }
 
     }
@@ -108,32 +146,33 @@ class WorkoutValidatorUnitTest {
                 FieldInfoError error = null;
                 Long id = invo.getArgument(0, Long.class);
 
-                if(id.equals(2L)) error = new FieldInfoErrorBuilder().name("accountRegisteredError").build();
                 if(id.equals(10L)) error = new FieldInfoErrorBuilder().name("accountRegisteredError").build();
 
                 return Optional.ofNullable(error);
             }).when(accountService).validateAccountRegistered(anyLong());
 
-            doAnswer(invo -> {
+            lenient().doAnswer(invo -> {
                 FieldInfoError error = null;
                 Long id = invo.getArgument(0, Long.class);
 
                 if(id.equals(2L)) error = new FieldInfoErrorBuilder().name("exerciseExistenceError").build();
+                if(id.equals(10L)) error = new FieldInfoErrorBuilder().name("exerciseExistenceError").build();
 
                 return Optional.ofNullable(error);
             }).when(exerciseService).validateExerciseExistence(anyLong());
 
-            doAnswer(invo -> {
+            lenient().doAnswer(invo -> {
                 FieldInfoError error = null;
                 Long id = invo.getArgument(0, Long.class);
 
+                if(id.equals(2L)) error = new FieldInfoErrorBuilder().name("allowanceByAccountIdError").build();
                 if(id.equals(3L)) error = new FieldInfoErrorBuilder().name("allowanceByAccountIdError").build();
                 if(id.equals(10L)) error = new FieldInfoErrorBuilder().name("allowanceByAccountIdError").build();
 
                 return Optional.ofNullable(error);
             }).when(identityVerificationService).validateAllowanceByAccountId(anyLong());
 
-            doAnswer(invo -> {
+            lenient().doAnswer(invo -> {
                 FieldInfoError error = null;
                 WorkoutRequestDto argRequestDto = invo.getArgument(0, WorkoutRequestDto.class);
 
@@ -141,14 +180,6 @@ class WorkoutValidatorUnitTest {
 
                 return Optional.ofNullable(error);
             }).when(workoutService).validatePerDayWorkoutLimit(any(WorkoutRequestDto.class), anyInt());
-        }
-
-        @AfterEach
-        void setUpAfterEach() {
-            verify(workoutService, times(1)).validatePerDayWorkoutLimit(eq(requestDto), eq(2));
-            verify(accountService, times(1)).validateAccountRegistered(requestDto.getAccountId());
-            verify(exerciseService, times(1)).validateExerciseExistence(requestDto.getExerciseId());
-            verify(identityVerificationService, times(1)).validateAllowanceByAccountId(requestDto.getAccountId());
         }
 
         @Test
@@ -161,11 +192,66 @@ class WorkoutValidatorUnitTest {
             requestDto = new WorkoutRequestDto(accountId, workoutDate, workoutLength, exerciseId);
 
             assertDoesNotThrow(() -> workoutValidator.validateRequest(requestDto));
+
+            verify(accountService, times(1)).validateAccountRegistered(eq(accountId));
+            verify(exerciseService, times(1)).validateExerciseExistence(eq(exerciseId));
+            verify(identityVerificationService, times(1)).validateAllowanceByAccountId(eq(accountId));
+            verify(workoutService, times(1)).validatePerDayWorkoutLimit(eq(requestDto), eq(2));
         }
 
         @Test
-        void shouldThrowMaximumAmountOfErrorsWhenAllFieldsAreInvalid(){
+        void shouldThrowMaximumOfTwoErrors(){
+            Long accountId = 3L;
+            LocalDate workoutDate = null;
+            short workoutLength = 2;
+            Long exerciseId = 1L;
+
+            requestDto = new WorkoutRequestDto(accountId, workoutDate, workoutLength, exerciseId);
+
+            list = assertThatExceptionOfType(ValidationServiceException.class)
+                .isThrownBy(() -> workoutValidator.validateRequest(requestDto))
+                .actual()
+                .getFieldErrors();
+
+            assertThat(list).isNotEmpty();
+            assertThat(list).hasSize(2);
+
+            assertThat(list).extracting(FieldInfoError::getName).containsOnlyOnce("perDayWorkoutLimitError");
+            assertThat(list).extracting(FieldInfoError::getName).containsOnlyOnce("allowanceByAccountIdError");
+
+            verify(accountService, times(1)).validateAccountRegistered(eq(accountId));
+            verify(exerciseService, times(1)).validateExerciseExistence(eq(exerciseId));
+            verify(identityVerificationService, times(1)).validateAllowanceByAccountId(eq(accountId));
+            verify(workoutService, times(1)).validatePerDayWorkoutLimit(eq(requestDto), eq(2));
+        }
+
+        @Test
+        void shouldThrowExceptionWhenOnlyAccountIsNotRegistered() {
             Long accountId = 10L;
+            LocalDate workoutDate = null;
+            short workoutLength = 2;
+            Long exerciseId = 10L;
+
+            requestDto = new WorkoutRequestDto(accountId, workoutDate, workoutLength, exerciseId);
+
+            list = assertThatExceptionOfType(ValidationServiceException.class)
+                .isThrownBy(() -> workoutValidator.validateRequest(requestDto))
+                .actual()
+                .getFieldErrors();
+
+            assertThat(list).hasSize(1);
+
+            assertThat(list).extracting(FieldInfoError::getName).containsOnly("accountRegisteredError");
+
+            verify(accountService, times(1)).validateAccountRegistered(eq(accountId));
+            verifyNoInteractions(exerciseService);
+            verifyNoInteractions(identityVerificationService);
+            verifyNoInteractions(workoutService);
+        }
+
+        @Test
+        void shouldThrowExceptionOnlyExerciseDoesNotExist() {
+            Long accountId = 1L;
             LocalDate workoutDate = null;
             short workoutLength = 2;
             Long exerciseId = 2L;
@@ -177,57 +263,18 @@ class WorkoutValidatorUnitTest {
                 .actual()
                 .getFieldErrors();
 
-            assertThat(list).isNotEmpty();
-            assertThat(list).hasSize(4);
-
-            assertThat(list).extracting(FieldInfoError::getName).contains("exerciseExistenceError");
-            assertThat(list).extracting(FieldInfoError::getName).contains("perDayWorkoutLimitError");
-            assertThat(list).extracting(FieldInfoError::getName).contains("accountRegisteredError");
-            assertThat(list).extracting(FieldInfoError::getName).contains("allowanceByAccountIdError");
-        }
-
-        @Test
-        void shouldThrowExceptionWhenAccountIsNotRegistered() {
-            Long accountId = 2L;
-            LocalDate workoutDate = null;
-            short workoutLength = 1;
-            Long exerciseId = 1L;
-
-            requestDto = new WorkoutRequestDto(accountId, workoutDate, workoutLength, exerciseId);
-
-            list = assertThatExceptionOfType(ValidationServiceException.class)
-                .isThrownBy(() -> workoutValidator.validateRequest(requestDto))
-                .actual()
-                .getFieldErrors();
-
-            assertThat(list).isNotEmpty();
-            assertThat(list).hasSize(1);
-
-            assertThat(list).extracting(FieldInfoError::getName).containsOnly("accountRegisteredError");
-        }
-
-        @Test
-        void shouldThrowExceptionWhenExerciseDoesNotExist() {
-            Long accountId = 1L;
-            LocalDate workoutDate = null;
-            short workoutLength = 1;
-            Long exerciseId = 2L;
-
-            requestDto = new WorkoutRequestDto(accountId, workoutDate, workoutLength, exerciseId);
-
-            list = assertThatExceptionOfType(ValidationServiceException.class)
-                .isThrownBy(() -> workoutValidator.validateRequest(requestDto))
-                .actual()
-                .getFieldErrors();
-
-            assertThat(list).isNotEmpty();
             assertThat(list).hasSize(1);
 
             assertThat(list).extracting(FieldInfoError::getName).containsOnly("exerciseExistenceError");
+
+            verify(accountService, times(1)).validateAccountRegistered(eq(accountId));
+            verify(exerciseService, times(1)).validateExerciseExistence(eq(exerciseId));
+            verifyNoInteractions(identityVerificationService);
+            verifyNoInteractions(workoutService);
         }
 
         @Test
-        void shouldThrowExceptionWhenUserIsNotAllowed() {
+        void shouldThrowExceptionWithOnlyInvalidAllowanceError() {
             Long accountId = 3L;
             LocalDate workoutDate = null;
             short workoutLength = 1;
@@ -244,10 +291,15 @@ class WorkoutValidatorUnitTest {
             assertThat(list).hasSize(1);
 
             assertThat(list).extracting(FieldInfoError::getName).containsOnly("allowanceByAccountIdError");
+
+            verify(accountService, times(1)).validateAccountRegistered(eq(accountId));
+            verify(exerciseService, times(1)).validateExerciseExistence(eq(exerciseId));
+            verify(identityVerificationService, times(1)).validateAllowanceByAccountId(eq(accountId));
+            verify(workoutService, times(1)).validatePerDayWorkoutLimit(eq(requestDto), eq(2));
         }
 
         @Test
-        void shouldThrowExceptionWhenPerDayWorkoutLimitIsExceeded() {
+        void shouldThrowExceptionWithOnlyPerDayWorkoutLimitError() {
             Long accountId = 1L;
             LocalDate workoutDate = null;
             short workoutLength = 2;
@@ -264,6 +316,11 @@ class WorkoutValidatorUnitTest {
             assertThat(list).hasSize(1);
 
             assertThat(list).extracting(FieldInfoError::getName).containsOnly("perDayWorkoutLimitError");
+
+            verify(accountService, times(1)).validateAccountRegistered(eq(accountId));
+            verify(exerciseService, times(1)).validateExerciseExistence(eq(exerciseId));
+            verify(identityVerificationService, times(1)).validateAllowanceByAccountId(eq(accountId));
+            verify(workoutService, times(1)).validatePerDayWorkoutLimit(eq(requestDto), eq(2));
         }
 
     }

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetValidatorUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetValidatorUnitTest.java
@@ -9,8 +9,10 @@ import static org.mockito.ArgumentMatchers.anyByte;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -59,29 +61,28 @@ class WorkoutSetValidatorUnitTest {
 
             doAnswer(invo ->{
                 FieldInfoError responseError = null;
-                final Long ARG_WORKOUT_ID = invo.getArgument(0, Long.class);
-                if(ARG_WORKOUT_ID.equals(2L) || ARG_WORKOUT_ID.equals(4L)){
+                final Long argWorkoutId = invo.getArgument(0, Long.class);
+                if(argWorkoutId.equals(2L) || argWorkoutId.equals(4L)){
                     responseError = new FieldInfoErrorBuilder().name("workoutExistence").build();
                 }
                 return Optional.ofNullable(responseError);
             }).when(workoutValidationService).validateWorkoutExistence(anyLong());
 
-            doAnswer(invo ->{
+            lenient().doAnswer(invo -> {
                 FieldInfoError responseError = null;
-                final WorkoutSetRequestDto ARG_REQUEST_DTO = invo.getArgument(0, WorkoutSetRequestDto.class);
-                if(ARG_REQUEST_DTO.getSets().size() > 4) responseError = new FieldInfoErrorBuilder().name("workoutSetLimit").build();
-                return Optional.ofNullable(responseError);
-            }).when(setValidationService).validateWorkoutSetLimit(any(WorkoutSetRequestDto.class), anyByte());
-
-            doAnswer(invo -> {
-                FieldInfoError responseError = null;
-                final Long ARG_WORKOUT_ID = invo.getArgument(0, Long.class);
-                if(ARG_WORKOUT_ID.equals(3L) || ARG_WORKOUT_ID.equals(4L)) {
+                final Long argWorkoutId = invo.getArgument(0, Long.class);
+                if(argWorkoutId.equals(3L) || argWorkoutId.equals(4L)) {
                     responseError = new FieldInfoErrorBuilder().name("workoutAllowance").build();
                 }
                 return Optional.ofNullable(responseError);
             }).when(identityVerificationService).validateUserAllowanceByWorkoutId(anyLong());
 
+            lenient().doAnswer(invo ->{
+                FieldInfoError responseError = null;
+                final WorkoutSetRequestDto argRequestDto = invo.getArgument(0, WorkoutSetRequestDto.class);
+                if(argRequestDto.getSets().size() > 4) responseError = new FieldInfoErrorBuilder().name("workoutSetLimit").build();
+                return Optional.ofNullable(responseError);
+            }).when(setValidationService).validateWorkoutSetLimit(any(WorkoutSetRequestDto.class), anyByte());
         }
 
         @Test
@@ -100,8 +101,8 @@ class WorkoutSetValidatorUnitTest {
         }
 
         @Test
-        void shouldThrowMaximumErrorAmountWhenAllConditionsAreInvalid() {
-            Long workoutId = 4L;
+        void shouldThrowMaximumOfTwoErrors() {
+            Long workoutId = 3L;
 
             List<SetRequestDto> sets = givenSetRequestDtoList();
 
@@ -118,10 +119,10 @@ class WorkoutSetValidatorUnitTest {
             expectedErrors = assertThatExceptionOfType(ValidationServiceException.class)
                 .isThrownBy(() -> workoutSetValidator.validateSaveAllRequest(requestDto)).actual().getFieldErrors();
 
-            assertThat(expectedErrors).hasSize(3);
+            assertThat(expectedErrors).hasSize(2);
 
             assertThat(expectedErrors).extracting(FieldInfoError::getName)
-                .containsOnlyOnce("workoutExistence", "workoutSetLimit", "workoutAllowance");
+                .containsOnlyOnce("workoutSetLimit", "workoutAllowance");
 
             verify(workoutValidationService, times(1)).validateWorkoutExistence(eq(requestDto.getWorkoutId()));
             verify(setValidationService, times(1)).validateWorkoutSetLimit(eq(requestDto), eq((byte)10));
@@ -161,7 +162,7 @@ class WorkoutSetValidatorUnitTest {
         void shouldThrowExceptionWhenOnlyWorkoutExistenceIsInvalid(){
             Long workoutId = 2L;
 
-            List<SetRequestDto> sets = new ArrayList<>();
+            List<SetRequestDto> sets = givenSetRequestDtoList();
 
             Integer repAmount = null;
 
@@ -181,8 +182,8 @@ class WorkoutSetValidatorUnitTest {
             assertThat(expectedErrors).extracting(FieldInfoError::getName).containsOnlyOnce("workoutExistence");
 
             verify(workoutValidationService, times(1)).validateWorkoutExistence(eq(requestDto.getWorkoutId()));
-            verify(setValidationService, times(1)).validateWorkoutSetLimit(eq(requestDto), eq((byte)10));
-            verify(identityVerificationService, times(1)).validateUserAllowanceByWorkoutId(eq(requestDto.getWorkoutId()));
+            verifyNoMoreInteractions(setValidationService);
+            verifyNoMoreInteractions(identityVerificationService);
         }
 
         @Test


### PR DESCRIPTION
This PR removes 404 not found responses from sub-modules(workout and workout-set) and replaces it with 400 bad request responses.

### Current Endpoints affected:

- POST `api/workouts`

- POST `api/workouts/{Account ID}`

- POST `api/workout-sets`

