### PR TITLE
Add view all workout sets by workout id endpoint

### DIFF
--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetController.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,6 +28,12 @@ class WorkoutSetController {
     ResponseEntity<List<WorkoutSetResponseDto>> createAll(@Validated (GroupsOrder.class) @RequestBody WorkoutSetRequestDto requestDto) {
         List<WorkoutSetResponseDto> responseDto = workoutSetService.saveAll(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
+    @GetMapping("/{workoutId}")
+    ResponseEntity<List<WorkoutSetResponseDto>> findAllByWorkoutId(@PathVariable Long workoutId) {
+        List<WorkoutSetResponseDto> responseList = workoutSetService.getAllByWorkoutId(workoutId);
+        return ResponseEntity.ok(responseList);
     }
 
 }

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetRepository.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetRepository.java
@@ -1,9 +1,13 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.workoutset;
 
+import java.util.List;
+
 import org.springframework.data.repository.CrudRepository;
 
 interface WorkoutSetRepository extends CrudRepository<WorkoutSet, Long> {
 
     short countByWorkoutId(Long workoutId);
+
+    List<WorkoutSet> findAllByWorkoutId(Long workoutId);
 
 }

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetService.java
@@ -44,6 +44,8 @@ class WorkoutSetService {
 
     @Transactional(readOnly = true)
     List<WorkoutSetResponseDto> getAllByWorkoutId(Long workoutId) {
+        workoutSetValidator.validateByIdRequest(workoutId);
+
         List<WorkoutSet> entityList = workoutSetRepository.findAllByWorkoutId(workoutId);
 
         List<WorkoutSetResponseDto> responseList = entityList

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetService.java
@@ -42,5 +42,17 @@ class WorkoutSetService {
         return responseDto;
     }
 
+    @Transactional(readOnly = true)
+    List<WorkoutSetResponseDto> getAllByWorkoutId(Long workoutId) {
+        List<WorkoutSet> entityList = workoutSetRepository.findAllByWorkoutId(workoutId);
+
+        List<WorkoutSetResponseDto> responseList = entityList
+            .stream()
+            .map(WorkoutSetMapper::entityToResponse)
+            .collect(Collectors.toList());
+
+        return responseList;
+    }
+
 
 }

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetValidator.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetValidator.java
@@ -42,4 +42,17 @@ class WorkoutSetValidator {
         errorFields.throwFieldErrors();
     }
 
+    void validateByIdRequest(Long workoutId) {
+        ValidationServiceErrorList errorFields = new ValidationServiceErrorList();
+
+        workoutValidationService.validateWorkoutExistence(workoutId).ifPresent(error -> {
+            errorFields.add(error);
+            errorFields.throwFieldErrors();
+        });
+
+        identityVerificationService.validateUserAllowanceByWorkoutId(workoutId).ifPresent(errorFields::add);
+
+        errorFields.throwFieldErrors();
+    }
+
 }

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetControllerTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetControllerTest.java
@@ -2,13 +2,18 @@ package com.crhistianm.springboot.gallo.springboot_gallo.workoutset;
 
 import static com.crhistianm.springboot.gallo.springboot_gallo.workoutset.WorkoutSetData.givenSetRequestDtoList;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.aspectj.lang.annotation.Before;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -103,6 +108,48 @@ class WorkoutSetControllerTest {
                 .andExpect(jsonPath("$.workoutId").value("the field workoutId must not be null"));
         }
     
+    }
+
+    @Nested
+    class ViewModuleTest {  
+
+        @BeforeEach
+        void setUp() {
+            doAnswer(invo -> {
+                List<WorkoutSetResponseDto> responseList = new ArrayList<>();
+
+                Integer repAmount = 10;
+                Double weightAmount = 10.00;
+                boolean toFailure = false;
+
+                WorkoutSetResponseDto responseDto = new WorkoutSetResponseDto(repAmount, weightAmount, toFailure);
+
+                repAmount = 20;
+                weightAmount = 20.00;
+                toFailure = true;
+
+                WorkoutSetResponseDto responseDto2 = new WorkoutSetResponseDto(repAmount, weightAmount, toFailure);
+
+                responseList.add(responseDto);
+                responseList.add(responseDto2);
+
+                return responseList;
+            }).when(workoutSetService).getAllByWorkoutId(anyLong());
+
+        }
+
+        @Test
+        void shouldReturnResponseList() throws Exception {
+            mockMvc.perform(get("/api/workout-sets/1").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("[0].repAmount").value(10))
+                .andExpect(jsonPath("[0].weightAmount").value(10.00))
+                .andExpect(jsonPath("[0].toFailure").value(false))
+                .andExpect(jsonPath("[1].repAmount").value(20))
+                .andExpect(jsonPath("[1].weightAmount").value(20.00))
+                .andExpect(jsonPath("[1].toFailure").value(true));
+        }
+
     }
 
 }

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetServiceUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetServiceUnitTest.java
@@ -139,7 +139,7 @@ class WorkoutSetServiceUnitTest {
 
         @BeforeEach
         void setUp() {
-            doAnswer(invo -> {
+            lenient().doAnswer(invo -> {
                 final Long argWorkoutId = invo.getArgument(0, Long.class);
                 List<WorkoutSet> entityList = new ArrayList<>();
 
@@ -150,9 +150,9 @@ class WorkoutSetServiceUnitTest {
                     set1.setRepAmount((byte)10);
 
                     WorkoutSet set2 = new WorkoutSet();
-                    set1.setWeightAmount(20.00);
-                    set1.setToFailure(true);
-                    set1.setRepAmount((byte)20);
+                    set2.setWeightAmount(20.00);
+                    set2.setToFailure(true);
+                    set2.setRepAmount((byte)20);
 
                     entityList.add(set1);
                     entityList.add(set2);
@@ -160,6 +160,12 @@ class WorkoutSetServiceUnitTest {
 
                 return entityList;
             }).when(workoutSetRepository).findAllByWorkoutId(anyLong());
+
+            doAnswer(invo -> {
+                final Long argWorkoutId = invo.getArgument(0, Long.class);
+                if(argWorkoutId.equals(10L)) throw new ValidationServiceException();
+                return null;
+            }).when(workoutSetValidator).validateByIdRequest(anyLong());
 
         }
 
@@ -172,6 +178,7 @@ class WorkoutSetServiceUnitTest {
             assertThat(responseList).isEmpty();
 
             verify(workoutSetRepository, times(1)).findAllByWorkoutId(eq(workoutId));
+            verify(workoutSetValidator).validateByIdRequest(eq(workoutId));
         }
 
         @Test
@@ -183,6 +190,18 @@ class WorkoutSetServiceUnitTest {
             assertThat(responseList).isNotEmpty();
 
             verify(workoutSetRepository, times(1)).findAllByWorkoutId(eq(workoutId));
+            verify(workoutSetValidator).validateByIdRequest(eq(workoutId));
+        }
+
+        @Test
+        void shouldThrowExceptionWhenRequestIsInvalid() {
+            workoutId = 10L;
+
+            assertThatExceptionOfType(ValidationServiceException.class)
+                .isThrownBy(() -> workoutSetService.getAllByWorkoutId(workoutId));
+
+            verifyNoInteractions(workoutSetRepository);
+            verify(workoutSetValidator).validateByIdRequest(eq(workoutId));
         }
 
     }

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetServiceUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetServiceUnitTest.java
@@ -3,6 +3,7 @@ package com.crhistianm.springboot.gallo.springboot_gallo.workoutset;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -126,6 +128,61 @@ class WorkoutSetServiceUnitTest {
             verify(workoutSetValidator, times(1)).validateSaveAllRequest(eq(requestDto));
             verifyNoInteractions(entityManager);
             verifyNoInteractions(workoutSetRepository);
+        }
+
+    }
+
+    @Nested
+    class ViewModuleTest {
+
+        Long workoutId;
+
+        @BeforeEach
+        void setUp() {
+            doAnswer(invo -> {
+                final Long argWorkoutId = invo.getArgument(0, Long.class);
+                List<WorkoutSet> entityList = new ArrayList<>();
+
+                if(argWorkoutId.equals(1L)) {
+                    WorkoutSet set1 = new WorkoutSet();
+                    set1.setWeightAmount(10.00);
+                    set1.setToFailure(false);
+                    set1.setRepAmount((byte)10);
+
+                    WorkoutSet set2 = new WorkoutSet();
+                    set1.setWeightAmount(20.00);
+                    set1.setToFailure(true);
+                    set1.setRepAmount((byte)20);
+
+                    entityList.add(set1);
+                    entityList.add(set2);
+                }
+
+                return entityList;
+            }).when(workoutSetRepository).findAllByWorkoutId(anyLong());
+
+        }
+
+        @Test
+        void shouldReturnEmptyWorkoutSetList() {
+            workoutId = 2L;
+
+            List<WorkoutSetResponseDto> responseList = workoutSetService.getAllByWorkoutId(workoutId);
+
+            assertThat(responseList).isEmpty();
+
+            verify(workoutSetRepository, times(1)).findAllByWorkoutId(eq(workoutId));
+        }
+
+        @Test
+        void shouldReturnFilledWorkoutSetList() {
+            workoutId = 1L;
+
+            List<WorkoutSetResponseDto> responseList = workoutSetService.getAllByWorkoutId(workoutId);
+
+            assertThat(responseList).isNotEmpty();
+
+            verify(workoutSetRepository, times(1)).findAllByWorkoutId(eq(workoutId));
         }
 
     }

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetValidatorUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetValidatorUnitTest.java
@@ -215,5 +215,70 @@ class WorkoutSetValidatorUnitTest {
         }
 
     }
+
+
+    @Nested
+    class ValidateByIdRequestMethodTest {
+
+        List<FieldInfoError> expectedErrors;
+
+        Long workoutdId;
+
+        @BeforeEach
+        void setUp() {
+            doAnswer(invo ->{
+                FieldInfoError responseError = null;
+                final Long argWorkoutId = invo.getArgument(0, Long.class);
+                if(argWorkoutId.equals(4L)){
+                    responseError = new FieldInfoErrorBuilder().name("workoutExistence").build();
+                }
+                return Optional.ofNullable(responseError);
+            }).when(workoutValidationService).validateWorkoutExistence(anyLong());
+
+            lenient().doAnswer(invo -> {
+                FieldInfoError responseError = null;
+                final Long argWorkoutId = invo.getArgument(0, Long.class);
+                if(argWorkoutId.equals(3L) || argWorkoutId.equals(4L)) {
+                    responseError = new FieldInfoErrorBuilder().name("workoutAllowance").build();
+                }
+                return Optional.ofNullable(responseError);
+            }).when(identityVerificationService).validateUserAllowanceByWorkoutId(anyLong());
+        }
+
+        @Test
+        void shouldThrowExceptionWhenOnlyWorkoutExistenceIsInvalid(){
+            Long workoutId = 4L;
+
+            expectedErrors = assertThatExceptionOfType(ValidationServiceException.class)
+                .isThrownBy(() -> workoutSetValidator.validateByIdRequest(workoutId))
+                .actual()
+                .getFieldErrors();
+
+            assertThat(expectedErrors).hasSize(1);
+
+            assertThat(expectedErrors).extracting(FieldInfoError::getName).containsOnlyOnce("workoutExistence");
+
+            verify(workoutValidationService, times(1)).validateWorkoutExistence(eq(workoutId));
+            verifyNoMoreInteractions(identityVerificationService);
+        }
+
+        @Test
+        void shouldThrowExceptionWhenOnlyWorkoutUserAllowanceIsInvalid() {
+            Long workoutId = 3L;
+
+            expectedErrors = assertThatExceptionOfType(ValidationServiceException.class)
+                .isThrownBy(() -> workoutSetValidator.validateByIdRequest(workoutId))
+                .actual()
+                .getFieldErrors();
+
+            assertThat(expectedErrors).hasSize(1);
+
+            assertThat(expectedErrors).extracting(FieldInfoError::getName).containsOnlyOnce("workoutAllowance");
+
+            verify(workoutValidationService, times(1)).validateWorkoutExistence(eq(workoutId));
+            verify(identityVerificationService, times(1)).validateUserAllowanceByWorkoutId(eq(workoutId));
+        }
+
+    }
     
 }


### PR DESCRIPTION
This PR adds the following:

### Endpoint added: GET `api/workout-sets/{Workout ID}`

### JSON Response example:

```json
[
  {
    "repAmount": 0,
    "weightAmount": 0.1,
    "toFailure": true
  },
  ......
]
```

>[!NOTE]
> General documentation and other responses are documented on OpenAPI definition.

> Tests for this feature are included in this PR.
