### PR TITLE
Add view all exercises endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,22 @@ jobs:
       - name: Run Refreshtoken Tests
         run: ./mvnw test -Prefreshtoken-tests
 
+  exercise-tests:
+    name: Backend - Exercise Tests
+    runs-on: ubuntu-latest
+    needs: build
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Run Exercise Tests
+        run: ./mvnw test -Pexercise-tests
 
   general-shared-tests:
     name: Backend - General Shared Tests

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -258,6 +258,22 @@
   </profile>
 
   <profile>
+    <id>exercise-tests</id>
+    <build>
+      <plugins>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <includes>
+              <include>**/exercise/*Test.java</include>
+            </includes>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
+  </profile>
+
+  <profile>
     <id>general-shared-tests</id>
     <build>
       <plugins>

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/Exercise.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/Exercise.java
@@ -23,7 +23,6 @@ import jakarta.persistence.UniqueConstraint;
 @Table(name = "exercise")
 public class Exercise {
 
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -51,11 +50,11 @@ public class Exercise {
     )
     private List<BodyPart> bodyParts;
 
-    public Exercise() {
+    Exercise() {
         this.bodyParts = new ArrayList<>();
     }
 
-    public Exercise(String name, String description, Boolean weightRequired, String imageUrl) {
+    Exercise(String name, String description, Boolean weightRequired, String imageUrl) {
         this();
         this.name = name;
         this.description = description;

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseController.java
@@ -1,0 +1,25 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.exercise;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/exercises")
+class ExerciseController {
+
+    private final ExerciseService exerciseService;
+
+    ExerciseController(ExerciseService exerciseService) {
+        this.exerciseService = exerciseService;
+    }
+
+    @GetMapping
+    ResponseEntity<List<ExerciseResponseDto>> viewAll() {
+        return ResponseEntity.ok(exerciseService.getAll());
+    }
+    
+}

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseMapper.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseMapper.java
@@ -1,0 +1,17 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.exercise;
+
+class ExerciseMapper {
+
+    static ExerciseResponseDto entityToResponse(Exercise entity) {
+        ExerciseResponseDto responseDto = new ExerciseResponseDto();
+
+        responseDto.setId(entity.getId());
+        responseDto.setName(entity.getName());
+        responseDto.setDescription(entity.getDescription());
+        responseDto.setWeightRequired(entity.getWeightRequired());
+        responseDto.setImageUrl(entity.getImageUrl());
+
+        return responseDto;
+    }
+    
+}

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseRepository.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseRepository.java
@@ -1,5 +1,11 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.exercise;
 
+import java.util.List;
+
 import org.springframework.data.repository.CrudRepository;
 
-interface ExerciseRepository extends CrudRepository<Exercise, Long> {}
+interface ExerciseRepository extends CrudRepository<Exercise, Long> {
+
+    List<Exercise> findAll();
+
+}

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseResponseDto.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseResponseDto.java
@@ -1,0 +1,108 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.exercise;
+
+class ExerciseResponseDto {
+
+    private Long id;
+
+    private String name;
+
+    private String description;
+
+    private boolean weightRequired;
+
+    private String imageUrl;
+
+    ExerciseResponseDto(){}
+
+    ExerciseResponseDto(Long id, String name, String description, boolean weightRequired, String imageUrl) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.weightRequired = weightRequired;
+        this.imageUrl = imageUrl;
+    }
+
+    Long getId() {
+        return id;
+    }
+
+    void setId(Long id) {
+        this.id = id;
+    }
+
+    String getName() {
+        return name;
+    }
+
+    void setName(String name) {
+        this.name = name;
+    }
+
+    String getDescription() {
+        return description;
+    }
+
+    void setDescription(String description) {
+        this.description = description;
+    }
+
+    boolean isWeightRequired() {
+        return weightRequired;
+    }
+
+    void setWeightRequired(boolean weightRequired) {
+        this.weightRequired = weightRequired;
+    }
+
+    String getImageUrl() {
+        return imageUrl;
+    }
+
+    void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((description == null) ? 0 : description.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ExerciseResponseDto other = (ExerciseResponseDto) obj;
+        if (id == null) {
+            if (other.id != null)
+                return false;
+        } else if (!id.equals(other.id))
+            return false;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        if (description == null) {
+            if (other.description != null)
+                return false;
+        } else if (!description.equals(other.description))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "ExerciseResponseDto [id=" + id + ", name=" + name + ", description=" + description + ", weightRequired="
+                + weightRequired + ", imageUrl=" + imageUrl + "]";
+    }
+
+}

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseService.java
@@ -1,0 +1,29 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.exercise;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+class ExerciseService {
+
+    private ExerciseRepository exerciseRepository;
+
+    ExerciseService(ExerciseRepository exerciseRepository) {
+        this.exerciseRepository = exerciseRepository;
+    }
+
+    @Transactional(readOnly = true)
+    List<ExerciseResponseDto> getAll() {
+        List<ExerciseResponseDto> responseList = exerciseRepository.findAll()
+            .stream()
+            .map(ExerciseMapper::entityToResponse)
+            .collect(Collectors.toList());
+
+        return responseList;
+    }
+    
+    
+}

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseControllerTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseControllerTest.java
@@ -1,0 +1,73 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.exercise;
+
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.crhistianm.springboot.gallo.springboot_gallo.shared.config.JacksonConfig;
+
+@Import(JacksonConfig.class)
+@WebMvcTest(controllers = {ExerciseController.class})
+@AutoConfigureMockMvc(addFilters = false)
+public class ExerciseControllerTest {
+
+    @MockitoBean
+    private ExerciseService exerciseService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        doAnswer(invo -> {
+            Long id = 1L;
+            String name = "one";
+            String description = "des";
+            boolean weightRequired = false;
+            String imageUrl = "url";
+
+            ExerciseResponseDto exercise1 = new ExerciseResponseDto(id, name, description, weightRequired, imageUrl);
+
+            id = 2L;
+            name = "two";
+            description = "des2";
+            weightRequired = true;
+            imageUrl = "url2";
+
+            ExerciseResponseDto exercise2 = new ExerciseResponseDto(id, name, description, weightRequired, imageUrl);
+
+            return List.of(exercise1, exercise2);
+        }).when(exerciseService).getAll();
+
+    }
+
+    @Test
+    void shouldReturnResponseDtoList() throws Exception {
+        mockMvc.perform(get("/api/exercises"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("[0].id").value(1L))
+            .andExpect(jsonPath("[0].name").value("one"))
+            .andExpect(jsonPath("[0].description").value("des"))
+            .andExpect(jsonPath("[0].weightRequired").value(false))
+            .andExpect(jsonPath("[0].imageUrl").value("url"))
+            .andExpect(jsonPath("[1].id").value(2L))
+            .andExpect(jsonPath("[1].name").value("two"))
+            .andExpect(jsonPath("[1].description").value("des2"))
+            .andExpect(jsonPath("[1].weightRequired").value(true))
+            .andExpect(jsonPath("[1].imageUrl").value("url2"));
+    }
+
+}

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseMapperUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseMapperUnitTest.java
@@ -1,0 +1,26 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.exercise;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ExerciseMapperUnitTest {
+
+    @Test
+    void shouldReturnResponeDto() {
+        final String name = "exercise";
+        final String description = "description";
+        final boolean weightRequired = false;
+        final String imageUrl = "url";
+
+        final Exercise entity = new Exercise(name, description, weightRequired, imageUrl);
+
+        ExerciseResponseDto expectedResponse = ExerciseMapper.entityToResponse(entity);
+
+        assertThat(expectedResponse).extracting(ExerciseResponseDto::getName).isEqualTo(name);
+        assertThat(expectedResponse).extracting(ExerciseResponseDto::getImageUrl).isEqualTo(imageUrl);
+        assertThat(expectedResponse).extracting(ExerciseResponseDto::getDescription).isEqualTo(description);
+        assertThat(expectedResponse).extracting(ExerciseResponseDto::isWeightRequired).isEqualTo(weightRequired);
+    }
+   
+}

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseServiceUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseServiceUnitTest.java
@@ -1,0 +1,48 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.exercise;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ExerciseServiceUnitTest {
+
+    @Mock
+    private ExerciseRepository exerciseRepository;
+
+    @InjectMocks
+    private ExerciseService exerciseService;
+
+    @BeforeEach
+    void setUp() {
+        doAnswer(invo -> {
+            String name = "one";
+            String description = "des";
+            boolean weightRequired = false;
+            String imageUrl = "url";
+            Exercise exercise1 = new Exercise(name, description, weightRequired, imageUrl);
+            Exercise exercise2 = new Exercise(name, description, weightRequired, imageUrl);
+            return List.of(exercise1, exercise2);
+        }).when(exerciseRepository).findAll();
+    }
+
+    @Test
+    void shouldReturnResponseList() {
+        List<ExerciseResponseDto> responseDto = exerciseService.getAll();
+
+        assertThat(responseDto).hasSize(2);
+
+        verify(exerciseRepository, times(1)).findAll();
+    }
+    
+}


### PR DESCRIPTION
This PR adds the following:

### Endpoint added: GET `api/exercises`

Functionality to get Gallo list of all exercises.

### JSON Response example:

```json
[
  {
    "id": 0,
    "name": "string",
    "description": "string",
    "weightRequired": true,
    "imageUrl": "string"
  },
  ....
]
```

>[!NOTE]
> General documentation and other responses are documented on OpenAPI definition.

> Tests for this feature are included in this PR.

### Solved:
Resolves #139 
