### PR TITLE
Add view all body parts by exercise ID endpoint

### DIFF
--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPart.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPart.java
@@ -1,10 +1,15 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.bodypart;
 
+import java.util.List;
+
+import com.crhistianm.springboot.gallo.springboot_gallo.exercise.Exercise;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
 
 @Entity
@@ -17,6 +22,9 @@ public class BodyPart {
 
     @Column(unique = true, length = 45, nullable = false)
     private String name;
+
+    @ManyToMany(mappedBy = "bodyParts")
+    private List<Exercise> exercises;
 
     BodyPart() {
     }
@@ -39,6 +47,14 @@ public class BodyPart {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public List<Exercise> getExercises() {
+        return exercises;
+    }
+
+    public void setExercises(List<Exercise> exercises) {
+        this.exercises = exercises;
     }
 
     @Override

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartController.java
@@ -8,6 +8,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
 @RestController
 @RequestMapping("api/body-parts")
 class BodyPartController {
@@ -24,6 +27,11 @@ class BodyPartController {
     }
 
     @GetMapping("/{exerciseId}")
+    @Operation(
+        responses = {
+            @ApiResponse(responseCode = "404", content = {})
+        }
+    )
     ResponseEntity<List<BodyPartResponseDto>> viewAllByExerciseId(@PathVariable Long exerciseId) {
         List<BodyPartResponseDto> responseList = bodyPartService.getAllByExerciseId(exerciseId);
         return ResponseEntity.ok(responseList);

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,6 +21,12 @@ class BodyPartController {
     @GetMapping
     ResponseEntity<List<BodyPartResponseDto>> viewAll() {
         return ResponseEntity.ok(bodyPartService.getAll());
+    }
+
+    @GetMapping("/{exerciseId}")
+    ResponseEntity<List<BodyPartResponseDto>> viewAllByExerciseId(@PathVariable Long exerciseId) {
+        List<BodyPartResponseDto> responseList = bodyPartService.getAllByExerciseId(exerciseId);
+        return ResponseEntity.ok(responseList);
     }
     
 }

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartRepository.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartRepository.java
@@ -3,10 +3,14 @@ package com.crhistianm.springboot.gallo.springboot_gallo.bodypart;
 
 import java.util.List;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 interface BodyPartRepository extends CrudRepository<BodyPart, Long>{
 
     List<BodyPart> findAll();
+
+    @Query(value = "SELECT b FROM BodyPart b INNER JOIN b.exercises e WHERE e.id=?1")
+    List<BodyPart> findAllByExerciseId(Long exerciseId);
     
 }

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartService.java
@@ -11,8 +11,11 @@ class BodyPartService {
 
     private final BodyPartRepository bodyPartRepository;
 
-    BodyPartService(BodyPartRepository bodyPartRepository) {
+    private final BodyPartValidator bodyPartValidator;
+
+    BodyPartService(BodyPartRepository bodyPartRepository, BodyPartValidator bodyPartValidator) {
         this.bodyPartRepository = bodyPartRepository;
+        this.bodyPartValidator = bodyPartValidator;
     }
 
     @Transactional(readOnly = true)
@@ -22,6 +25,8 @@ class BodyPartService {
 
     @Transactional(readOnly = true)
     List<BodyPartResponseDto> getAllByExerciseId(Long exerciseId) {
+        bodyPartValidator.validateByIdRequest(exerciseId);
+
         List<BodyPart> entityList = bodyPartRepository.findAllByExerciseId(exerciseId);
 
         List<BodyPartResponseDto> responseList = entityList

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartService.java
@@ -20,5 +20,17 @@ class BodyPartService {
         return bodyPartRepository.findAll().stream().map(BodyPartMapper::entityToResponse).collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
+    List<BodyPartResponseDto> getAllByExerciseId(Long exerciseId) {
+        List<BodyPart> entityList = bodyPartRepository.findAllByExerciseId(exerciseId);
+
+        List<BodyPartResponseDto> responseList = entityList
+            .stream()
+            .map(BodyPartMapper::entityToResponse)
+            .collect(Collectors.toList());
+
+        return responseList;
+    }
+
 }
 

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartValidator.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartValidator.java
@@ -1,0 +1,27 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.bodypart;
+
+import org.springframework.stereotype.Component;
+
+import com.crhistianm.springboot.gallo.springboot_gallo.exercise.ExerciseValidationService;
+import com.crhistianm.springboot.gallo.springboot_gallo.shared.ValidationServiceErrorList;
+
+@Component
+class BodyPartValidator {
+
+    private final ExerciseValidationService exerciseValidationService;
+
+    BodyPartValidator(ExerciseValidationService exerciseValidationService) {
+        this.exerciseValidationService = exerciseValidationService;
+    }
+
+    void validateByIdRequest(Long exerciseId) {
+        ValidationServiceErrorList errorList = new ValidationServiceErrorList();
+
+        exerciseValidationService.validateExerciseExistence(exerciseId).ifPresent(error -> {
+            errorList.add(error);
+            errorList.throwFieldErrors();
+        });
+
+    }
+
+}

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/Exercise.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/Exercise.java
@@ -40,7 +40,6 @@ public class Exercise {
     @Column(nullable = true, length = 255)
     private String imageUrl;
 
-    //Not bidirectional as i only expect to need bodyparts of a exercise, not inverse
     @ManyToMany
     @JoinTable(
         name = "exercise_body_part",

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartControllerTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartControllerTest.java
@@ -1,8 +1,12 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.bodypart;
 
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -12,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -40,27 +45,74 @@ class BodyPartControllerTest {
     @MockitoBean
     private AccountUserDetailsService details;
 
-    @BeforeEach
-    void setUp() {
-        List<BodyPartResponseDto> bodyPartsResponse = new ArrayList<>();
-        bodyPartsResponse.add(BodyPartMapper.entityToResponse(new BodyPartBuilder().name("part1").id(1L).build()));
-        bodyPartsResponse.add(BodyPartMapper.entityToResponse(new BodyPartBuilder().name("part2").id(2L).build()));
-        bodyPartsResponse.add(BodyPartMapper.entityToResponse(new BodyPartBuilder().name("part3").id(3L).build()));
-        doReturn(bodyPartsResponse).when(bodyPartService).getAll();
+    @Nested
+    class ViewAllMethodTest {
+
+        @BeforeEach
+        void setUp() {
+            List<BodyPartResponseDto> bodyPartsResponse = new ArrayList<>();
+            bodyPartsResponse.add(BodyPartMapper.entityToResponse(new BodyPartBuilder().name("part1").id(1L).build()));
+            bodyPartsResponse.add(BodyPartMapper.entityToResponse(new BodyPartBuilder().name("part2").id(2L).build()));
+            bodyPartsResponse.add(BodyPartMapper.entityToResponse(new BodyPartBuilder().name("part3").id(3L).build()));
+            doReturn(bodyPartsResponse).when(bodyPartService).getAll();
+        }
+
+        @Test
+        void shouldReturnResponseListWhenRequestIsSent() throws Exception {
+            mockMvc.perform(request(HttpMethod.GET, "/api/body-parts"))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("[0].name").value("part1"))
+                .andExpect(jsonPath("[1].name").value("part2"))
+                .andExpect(jsonPath("[2].name").value("part3"))
+                .andExpect(jsonPath("[0].id").value(1L))
+                .andExpect(jsonPath("[1].id").value(2L))
+                .andExpect(jsonPath("[2].id").value(3L));
+
+            verify(bodyPartService, times(1)).getAll();
+        }
+
     }
 
-    @Test
-    void shouldReturnResponseListWhenViewAllRequestIsSent() throws Exception {
-        mockMvc.perform(request(HttpMethod.GET, "/api/body-parts"))
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("[0].name").value("part1"))
-            .andExpect(jsonPath("[1].name").value("part2"))
-            .andExpect(jsonPath("[2].name").value("part3"))
-            .andExpect(jsonPath("[0].id").value(1L))
-            .andExpect(jsonPath("[1].id").value(2L))
-            .andExpect(jsonPath("[2].id").value(3L));
+    @Nested
+    class GetAllByExerciseIdMethodTest {
 
-        verify(bodyPartService, times(1)).getAll();
+        @BeforeEach
+        void setUp() {
+            doAnswer(invo -> {
+                List<BodyPartResponseDto> responseList = new ArrayList<>();
+
+                String name = "part1";
+                Long id = 1L;
+
+                BodyPartResponseDto bodyPart1 = new BodyPartResponseDto(name, id);
+
+                name = "part2";
+                id = 2L;
+
+                BodyPartResponseDto bodyPart2 = new BodyPartResponseDto(name, id);
+                
+                responseList.add(bodyPart1);
+                responseList.add(bodyPart2);
+
+                return responseList;
+            }).when(bodyPartService).getAllByExerciseId(anyLong());
+        }
+
+        @Test
+        void shouldReturnResponseListWhenRequestIsSent() throws Exception {
+            final Long exerciseId = 1L;
+
+            mockMvc.perform(get(String.format("/api/body-parts/%d", exerciseId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("[0].name").value("part1"))
+                .andExpect(jsonPath("[0].id").value(1))
+                .andExpect(jsonPath("[1].name").value("part2"))
+                .andExpect(jsonPath("[1].id").value(2));
+
+            verify(bodyPartService, times(1)).getAllByExerciseId(eq(exerciseId));
+        }
+
     }
+
 }

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartRepositoryTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartRepositoryTest.java
@@ -1,0 +1,54 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.bodypart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.jdbc.Sql;
+
+@DataJpaTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+class BodyPartRepositoryTest {
+
+    @Autowired
+    private BodyPartRepository bodyPartRepository;
+
+    @Nested
+    @Sql(value = {"/exerciseinserts.sql", "/bodypartinserts.sql", "/exercisebodypartinserts.sql"})
+    class FindAllByExerciseIdMethodTest {
+
+        Long exerciseId;
+
+        @Test
+        void shouldReturnEmptyListWhenExerciseDoesNotExist() {
+            exerciseId = 3L;
+
+            List<BodyPart> entityList = bodyPartRepository.findAllByExerciseId(exerciseId);
+
+            assertThat(entityList).isEmpty();
+        }
+
+        @Test
+        void shouldReturnListWhenExerciseBodyPartsIsFound() {
+            exerciseId = 1L;
+
+            List<BodyPart> entityList = bodyPartRepository.findAllByExerciseId(exerciseId);
+
+            assertThat(entityList).isNotEmpty();
+            assertThat(entityList).hasSize(2);
+
+            assertThat(entityList).extracting(BodyPart::getName).containsOnlyOnce("part1");
+            assertThat(entityList).extracting(BodyPart::getName).containsOnlyOnce("part2");
+
+            assertThat(entityList).extracting(BodyPart::getId).containsOnlyOnce(1L);
+            assertThat(entityList).extracting(BodyPart::getId).containsOnlyOnce(2L);
+        }
+
+    }
+    
+}

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartServiceUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartServiceUnitTest.java
@@ -1,6 +1,9 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.bodypart;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatException;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -21,11 +24,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.crhistianm.springboot.gallo.springboot_gallo.shared.exception.ValidationServiceException;
+
 @ExtendWith(MockitoExtension.class)
 class BodyPartServiceUnitTest {
 
     @Mock
     private BodyPartRepository bodyPartRepository;
+
+    @Mock
+    private BodyPartValidator bodyPartValidator;
 
     @InjectMocks
     private BodyPartService bodyPartService;
@@ -69,8 +77,13 @@ class BodyPartServiceUnitTest {
 
         @BeforeEach
         void setUp() {
-
             doAnswer(invo -> {
+                final Long argExerciseID = invo.getArgument(0, Long.class);
+                if(argExerciseID.equals(99L)) throw new ValidationServiceException();
+                return null;
+            }).when(bodyPartValidator).validateByIdRequest(anyLong());
+
+            lenient().doAnswer(invo -> {
                 List<BodyPart> responseEntityList = new ArrayList<>();
 
                 responseEntityList.add(new BodyPartBuilder().name("part1").build());
@@ -90,10 +103,19 @@ class BodyPartServiceUnitTest {
             assertThat(expectedResponseList).isNotEmpty();
 
             verify(bodyPartRepository, times(1)).findAllByExerciseId(eq(exerciseId));
+            verify(bodyPartValidator, times(1)).validateByIdRequest(eq(exerciseId));
+        }
+
+        @Test
+        void shouldThrowExceptionWhenRequestIsInvalid() {   
+            exerciseId = 99L;
+
+            assertThatException().isThrownBy(() -> bodyPartService.getAllByExerciseId(exerciseId));
+
+            verify(bodyPartValidator, times(1)).validateByIdRequest(eq(exerciseId));
+            verifyNoInteractions(bodyPartRepository);
         }
 
     }
 
-
-    
 }

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartServiceUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartServiceUnitTest.java
@@ -1,56 +1,99 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.bodypart;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-
 @ExtendWith(MockitoExtension.class)
 class BodyPartServiceUnitTest {
 
     @Mock
-    BodyPartRepository bodyPartRepository;
+    private BodyPartRepository bodyPartRepository;
 
     @InjectMocks
-    BodyPartService bodyPartService;
+    private BodyPartService bodyPartService;
 
-    @BeforeEach
-    void setUp() {
-        List<BodyPart> entityBodyParts = new ArrayList<>();
-        entityBodyParts.add(new BodyPartBuilder().name("part1").id(1L).build());
-        entityBodyParts.add(new BodyPartBuilder().name("part2").id(2L).build());
-        entityBodyParts.add(new BodyPartBuilder().name("part3").id(3L).build());
-        doReturn(entityBodyParts).when(bodyPartRepository).findAll();
+    @Nested
+    class GetAllMethodTest {
+
+        @BeforeEach
+        void setUp() {
+            List<BodyPart> entityBodyParts = new ArrayList<>();
+            entityBodyParts.add(new BodyPartBuilder().name("part1").id(1L).build());
+            entityBodyParts.add(new BodyPartBuilder().name("part2").id(2L).build());
+            entityBodyParts.add(new BodyPartBuilder().name("part3").id(3L).build());
+            doReturn(entityBodyParts).when(bodyPartRepository).findAll();
+        }
+
+        @Test
+        void shouldReturnDtoListWhenMethodIsCalled() {
+            List<BodyPartResponseDto> bodyPartsReponse = bodyPartService.getAll();
+
+            assertThat(bodyPartsReponse).isNotEmpty();
+            assertThat(bodyPartsReponse).hasSize(3);
+
+            assertThat(bodyPartsReponse).extracting(BodyPartResponseDto::getName).contains("part1");
+            assertThat(bodyPartsReponse).extracting(BodyPartResponseDto::getName).contains("part2");
+            assertThat(bodyPartsReponse).extracting(BodyPartResponseDto::getName).contains("part3");
+
+            assertThat(bodyPartsReponse).extracting(BodyPartResponseDto::getId).contains(1L);
+            assertThat(bodyPartsReponse).extracting(BodyPartResponseDto::getId).contains(2L);
+            assertThat(bodyPartsReponse).extracting(BodyPartResponseDto::getId).contains(3L);
+
+            verify(bodyPartRepository, times(1)).findAll();
+        }
+
     }
 
-    @Test
-    void shouldReturnDtoListWhenMethodIsCalled() {
-        List<BodyPartResponseDto> bodyPartsReponse = bodyPartService.getAll();
+    @Nested
+    class GetAllByExerciseIdMethodTest {
 
-        assertThat(bodyPartsReponse).isNotEmpty();
-        assertThat(bodyPartsReponse).hasSize(3);
+        private Long exerciseId;
 
-        assertThat(bodyPartsReponse).extracting(BodyPartResponseDto::getName).contains("part1");
-        assertThat(bodyPartsReponse).extracting(BodyPartResponseDto::getName).contains("part2");
-        assertThat(bodyPartsReponse).extracting(BodyPartResponseDto::getName).contains("part3");
+        @BeforeEach
+        void setUp() {
 
-        assertThat(bodyPartsReponse).extracting(BodyPartResponseDto::getId).contains(1L);
-        assertThat(bodyPartsReponse).extracting(BodyPartResponseDto::getId).contains(2L);
-        assertThat(bodyPartsReponse).extracting(BodyPartResponseDto::getId).contains(3L);
+            doAnswer(invo -> {
+                List<BodyPart> responseEntityList = new ArrayList<>();
 
-        verify(bodyPartRepository, times(1)).findAll();
+                responseEntityList.add(new BodyPartBuilder().name("part1").build());
+                responseEntityList.add(new BodyPartBuilder().name("part2").build());
+                return responseEntityList;
+
+            }).when(bodyPartRepository).findAllByExerciseId(anyLong());
+
+        }
+
+        @Test
+        void shouldReturnResponseList() {
+            exerciseId = 1L;
+
+            List<BodyPartResponseDto> expectedResponseList = bodyPartService.getAllByExerciseId(exerciseId);
+
+            assertThat(expectedResponseList).isNotEmpty();
+
+            verify(bodyPartRepository, times(1)).findAllByExerciseId(eq(exerciseId));
+        }
+
     }
+
 
     
 }

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartValidatorUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartValidatorUnitTest.java
@@ -1,0 +1,76 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.bodypart;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.crhistianm.springboot.gallo.springboot_gallo.exercise.ExerciseValidationService;
+import com.crhistianm.springboot.gallo.springboot_gallo.shared.FieldInfoError;
+import com.crhistianm.springboot.gallo.springboot_gallo.shared.exception.ValidationServiceException;
+
+@ExtendWith(MockitoExtension.class)
+class BodyPartValidatorUnitTest {
+
+    @Mock
+    private ExerciseValidationService exerciseValidationService;
+
+    @InjectMocks
+    private BodyPartValidator bodyPartValidator;
+
+    @Nested
+    class ValidateByIdRequestTest {
+
+        Long exerciseId;
+
+        @BeforeEach
+        void setUp() {
+            doAnswer(invo -> {
+                FieldInfoError fieldError = null;
+
+                final Long argExerciseId = invo.getArgument(0, Long.class);
+
+                if(argExerciseId.equals(99L)) fieldError = new FieldInfoError();
+                
+                return Optional.ofNullable(fieldError);
+            }).when(exerciseValidationService).validateExerciseExistence(anyLong());
+
+        }
+
+        @Test
+        void shouldThrowExceptionWhenExerciseExistenceIsInvalid() {
+            exerciseId = 99L;
+
+            assertThatExceptionOfType(ValidationServiceException.class)
+                .isThrownBy(() -> bodyPartValidator.validateByIdRequest(exerciseId));
+
+            verify(exerciseValidationService, times(1)).validateExerciseExistence(eq(exerciseId));
+        }
+
+        @Test
+        void shouldNotThrowAnyException() {
+            exerciseId = 1L;
+
+            assertThatCode(() -> bodyPartValidator.validateByIdRequest(exerciseId))
+                .doesNotThrowAnyException();
+
+            verify(exerciseValidationService, times(1)).validateExerciseExistence(eq(exerciseId));
+        }
+
+    }
+   
+}

--- a/backend/src/test/resources/bodypartinserts.sql
+++ b/backend/src/test/resources/bodypartinserts.sql
@@ -1,0 +1,6 @@
+INSERT INTO body_part (id, name) VALUES
+(1, 'part1'),
+(2, 'part2');
+
+
+

--- a/backend/src/test/resources/exercisebodypartinserts.sql
+++ b/backend/src/test/resources/exercisebodypartinserts.sql
@@ -1,0 +1,5 @@
+INSERT INTO exercise_body_part (body_part_id, exercise_id) VALUES
+(1, 1),
+(2, 2),
+(2, 1);
+


### PR DESCRIPTION
This PR adds view body part by exercise id endpoint described as the following: 

### Endpoint: GET `api/body-parts/{exerciseID}`

## JSON response example:

```json
[
  {
    "name": "string",
    "id": 0
  },
  {
    "name": "string",
    "id": 0
  },
  .....
]
```

>[!NOTE]
> Further endpoint details can be found on documentation when released.

> Tests are included in this PR.


