### PR TITLE
Remove authentication requirements for register process endpoints 

### DIFF
--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountController.java
@@ -20,6 +20,7 @@ import com.crhistianm.springboot.gallo.springboot_gallo.shared.group.GroupsOrder
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import jakarta.validation.Valid;
 
 @RestController
@@ -39,6 +40,7 @@ class AccountController {
              ))
     )
     @PostMapping
+    @SecurityRequirements(value = {})
     ResponseEntity<AccountResponseDto> create(@Valid @RequestBody AccountRequestDto accountDto){
         return ResponseEntity.status(HttpStatus.CREATED).body(accountService.save(accountDto));
     }

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import jakarta.validation.Valid;
 
 
@@ -25,6 +26,7 @@ public class PersonController {
     private PersonService personService;
 
     @PostMapping
+    @SecurityRequirements(value = {})
     public ResponseEntity<PersonResponseDto> create(@Valid @RequestBody PersonRequestDto personDto){
         return ResponseEntity.status(HttpStatus.CREATED).body(personService.save(personDto));
     }

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/security/SpringSecurityConfig.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/security/SpringSecurityConfig.java
@@ -63,6 +63,8 @@ class SpringSecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/api/persons").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.GET, "/api/accounts").hasAnyRole("ADMIN")
                     .requestMatchers(HttpMethod.POST, "/api/auth/**").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/accounts").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/persons").permitAll()
                     .requestMatchers("/swagger-ui/**").hasRole("ADMIN")
                     .requestMatchers("/v3/api-docs/**").permitAll()
                     .requestMatchers("/apidocs.html").permitAll()


### PR DESCRIPTION
This PR removes API register proccess doing the following:

### Affected endpoints:

- POST `api/persons`

- POST `api/accounts`

JWT bearer authorization header is not needed for this endpoints.

>[!IMPORTANT]
> Account creation true admin field needs authorization header.
