### PR TITLE
Remove path ID ambiguity 

### DIFF
--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartController.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,15 +26,16 @@ class BodyPartController {
         return ResponseEntity.ok(bodyPartService.getAll());
     }
 
-    @GetMapping("/{exerciseId}")
+    @GetMapping(params = {"exerciseId"})
     @Operation(
         responses = {
             @ApiResponse(responseCode = "404", content = {})
         }
     )
-    ResponseEntity<List<BodyPartResponseDto>> viewAllByExerciseId(@PathVariable Long exerciseId) {
+    ResponseEntity<List<BodyPartResponseDto>> viewAllByExerciseId(@RequestParam(required = true) Long exerciseId) {
         List<BodyPartResponseDto> responseList = bodyPartService.getAllByExerciseId(exerciseId);
         return ResponseEntity.ok(responseList);
     }
+    //Tenes que ver como arreglar esto juntando ambos o viendo como
     
 }

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 @RestController
@@ -21,21 +22,28 @@ class BodyPartController {
         this.bodyPartService = bodyPartService;
     }
 
-    @GetMapping
-    ResponseEntity<List<BodyPartResponseDto>> viewAll() {
-        return ResponseEntity.ok(bodyPartService.getAll());
-    }
-
-    @GetMapping(params = {"exerciseId"})
     @Operation(
         responses = {
             @ApiResponse(responseCode = "404", content = {})
         }
     )
-    ResponseEntity<List<BodyPartResponseDto>> viewAllByExerciseId(@RequestParam(required = true) Long exerciseId) {
+    @GetMapping(name = "viewAll")
+    ResponseEntity<List<BodyPartResponseDto>> viewAll() {
+        return ResponseEntity.ok(bodyPartService.getAll());
+    }
+
+    @Operation(
+        responses = {
+            @ApiResponse(responseCode = "404", content = {})
+        }
+    )
+    @GetMapping(name = "viewAllByExerciseId", params = {"exerciseId"})
+    ResponseEntity<List<BodyPartResponseDto>> viewAllByExerciseId
+    (
+     @Parameter @RequestParam(required = false) Long exerciseId
+    ) {
         List<BodyPartResponseDto> responseList = bodyPartService.getAllByExerciseId(exerciseId);
         return ResponseEntity.ok(responseList);
     }
-    //Tenes que ver como arreglar esto juntando ambos o viendo como
-    
+
 }

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workout/WorkoutController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workout/WorkoutController.java
@@ -5,7 +5,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,9 +23,9 @@ class WorkoutController {
         this.workoutService = workoutService;
     }
 
-    @GetMapping("/{accountId}")
+    @GetMapping
     ResponseEntity<PagedModel<WorkoutResponseDto>> viewByAccountId (
-            @PathVariable Long accountId,
+            @RequestParam(required = true) Long accountId,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size
     ) {

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetController.java
@@ -6,10 +6,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.shared.group.GroupsOrder;
@@ -30,8 +30,8 @@ class WorkoutSetController {
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
-    @GetMapping("/{workoutId}")
-    ResponseEntity<List<WorkoutSetResponseDto>> findAllByWorkoutId(@PathVariable Long workoutId) {
+    @GetMapping
+    ResponseEntity<List<WorkoutSetResponseDto>> findAllByWorkoutId(@RequestParam(required = true) Long workoutId) {
         List<WorkoutSetResponseDto> responseList = workoutSetService.getAllByWorkoutId(workoutId);
         return ResponseEntity.ok(responseList);
     }

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartControllerTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/bodypart/BodyPartControllerTest.java
@@ -103,7 +103,7 @@ class BodyPartControllerTest {
         void shouldReturnResponseListWhenRequestIsSent() throws Exception {
             final Long exerciseId = 1L;
 
-            mockMvc.perform(get(String.format("/api/body-parts/%d", exerciseId)))
+            mockMvc.perform(get(String.format("/api/body-parts?exerciseId=%d", exerciseId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("[0].name").value("part1"))
                 .andExpect(jsonPath("[0].id").value(1))

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/security/SpringEndpointSecurityTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/security/SpringEndpointSecurityTest.java
@@ -235,7 +235,7 @@ class SpringEndpointSecurityTest {
 
             @Test
             void shouldReturnBadRequestStatusWhenViewPageGetRequestIsSent() throws Exception {
-                mockMvc.perform(get("/api/workouts/1?page=0&size=4")
+                mockMvc.perform(get("/api/workouts?workoutId=1&page=0&size=4")
                         .header("Authorization", prefixWithToken))
                     .andExpect(status().isBadRequest());
             }
@@ -359,7 +359,7 @@ class SpringEndpointSecurityTest {
 
             @Test
             void shouldReturnBadRequestStatusWhenViewPageGetRequestIsSent() throws Exception {
-                mockMvc.perform(get("/api/workouts/1?page=0&size=4")
+                mockMvc.perform(get("/api/workouts?accountId=1&page=0&size=4")
                         .header("Authorization", prefixWithToken))
                     .andExpect(status().isBadRequest());
             }

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/workout/WorkoutControllerTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/workout/WorkoutControllerTest.java
@@ -76,7 +76,7 @@ class WorkoutControllerTest {
             int size = 4;
             Long accountId = 1L;
 
-            String uri = String.format("/api/workouts/%d?page=%d&size=%d", accountId, page, size);
+            String uri = String.format("/api/workouts?accountId=%d&page=%d&size=%d", accountId, page, size);
 
             mockMvc.perform(request(HttpMethod.GET, uri))
                 .andExpect(status().isOk())

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetControllerTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/workoutset/WorkoutSetControllerTest.java
@@ -140,7 +140,7 @@ class WorkoutSetControllerTest {
 
         @Test
         void shouldReturnResponseList() throws Exception {
-            mockMvc.perform(get("/api/workout-sets/1").contentType(MediaType.APPLICATION_JSON))
+            mockMvc.perform(get("/api/workout-sets?workoutId=1").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("[0].repAmount").value(10))
                 .andExpect(jsonPath("[0].weightAmount").value(10.00))


### PR DESCRIPTION
 This PR removes path ID ambiguity replacing it by request parameter filter.

### Endpoints changed: 

- **GET from** `api/workouts/{account ID}` **to** `api/workouts?accountId=ID`

- **GET from** `api/workout-sets/{workout ID}` to `api/workout-sets?workoutId=ID`

- **GET from** `api/body-parts/{exercise ID}` **to** `api/body-parts?exerciseId=ID`

>[!IMPORTANT]
> All previous filters applied are **required**.

> Tests are included for this branch.

### Solved: 
Resolves #204 
