### PR TITLE
Add missing view all accounts endpoint pagination

### DIFF
--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountController.java
@@ -3,6 +3,7 @@ package com.crhistianm.springboot.gallo.springboot_gallo.account;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.web.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.shared.group.GroupsOrder;
@@ -76,11 +78,11 @@ class AccountController {
         }
     )
     @GetMapping
-    ResponseEntity<List<AccountAdminResponseDto>> viewAll(){
-        return ResponseEntity.ok(accountService.getAll());
+    ResponseEntity<PagedModel<AccountAdminResponseDto>> viewBy (
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size
+    ) {
+        return ResponseEntity.ok(accountService.getBy(page, size));
     }
-
-
-
-    
+   
 }

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountRepository.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountRepository.java
@@ -1,8 +1,9 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.account;
 
-import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
@@ -21,6 +22,6 @@ interface AccountRepository extends CrudRepository <Account, Long>{
     @Query("select a from Account a inner join a.workouts w where w.id=?1")
     Optional<Account> findAccountByWorkoutId(Long workoutId);
 
-    List<Account> findAll();
+    Page<Account> findBy(Pageable pageable);
 
 }

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountService.java
@@ -4,6 +4,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedModel;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -97,9 +101,10 @@ class AccountService {
     }
 
     @Transactional(readOnly = true)
-    List<AccountAdminResponseDto> getAll() {
-        List<AccountAdminResponseDto> accountList = accountRepository.findAll().stream().map(a -> (AccountAdminResponseDto) AccountMapper.entityToAdminResponse(a)).collect(Collectors.toList());
-        return accountList;
+    PagedModel<AccountAdminResponseDto> getBy(int page, int size) {
+        Page<AccountAdminResponseDto> accountPage = accountRepository.findBy(PageRequest.of(page, size))
+            .map(account -> (AccountAdminResponseDto) AccountMapper.entityToAdminResponse(account));
+        return new PagedModel<AccountAdminResponseDto>(accountPage);
     }
 
 }

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountControllerTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountControllerTest.java
@@ -6,9 +6,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.data.web.SpringDataWebProperties.Pageable;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.web.PagedModel;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -115,14 +118,40 @@ class AccountControllerTest {
         }
 
         @Test
-        void testViewAll() throws Exception {
-            when(accountService.getAll()).thenReturn(List.of((AccountAdminResponseDto)AccountMapper.entityToAdminResponse(givenAccountEntityAdmin().orElseThrow()), 
-                    (AccountAdminResponseDto)AccountMapper.entityToAdminResponse(givenAccountEntityUser().orElseThrow())));
-            mockMvc.perform(get("/api/accounts"))
-                .andExpect(jsonPath("$[0].id").value(1L))
-                .andExpect(jsonPath("$[1].id").value(1L))
-                .andExpect(jsonPath("$[0].email").value("admin@gmail.com"))
-                .andExpect(jsonPath("$[1].email").value("user@gmail.com"));
+        void testViewBy() throws Exception {
+            when(accountService.getBy(anyInt(), anyInt())).thenAnswer(answer -> {
+
+                List<AccountAdminResponseDto> responseList = new ArrayList<>() ;
+
+                AccountAdminResponseDto dto1 = new AccountAdminResponseDto();
+
+                dto1.setId(1L);
+                dto1.setEmail("admin@gmail.com");
+
+                AccountAdminResponseDto dto2 = new AccountAdminResponseDto();
+
+                dto2.setId(1L);
+                dto2.setEmail("user@gmail.com");
+
+                responseList.add(dto1);
+                responseList.add(dto2);
+
+                PageImpl<AccountAdminResponseDto> pageEntity = new PageImpl<>(responseList);
+                return new PagedModel<>(pageEntity);
+            });
+
+            final int page = 0;
+            final int size = 10;
+
+            mockMvc.perform(get(String.format("/api/accounts?page=%d&size=%d", page, size)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(2))
+                .andExpect(jsonPath("$.content.[0].id").value(1L))
+                .andExpect(jsonPath("$.content.[1].id").value(1L))
+                .andExpect(jsonPath("$.content.[0].email").value("admin@gmail.com"))
+                .andExpect(jsonPath("$.content.[1].email").value("user@gmail.com"));
+
+            verify(accountService, times(1)).getBy(eq(page), eq(size));
         }
 
         @Test

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountServiceUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountServiceUnitTest.java
@@ -23,6 +23,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedModel;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.shared.FieldInfoErrorBuilder;
@@ -87,12 +90,31 @@ class AccountServiceUnitTest {
         }
 
         @Test
-        void testGetAll(){
-            when(accountRepository.findAll()).thenReturn(List.of(givenAccountEntityAdmin().orElseThrow(), givenAccountEntityUser().orElseThrow()));
-            List<AccountAdminResponseDto> expectedList = List.of((AccountAdminResponseDto)AccountMapper.entityToAdminResponse(givenAccountEntityAdmin().orElseThrow()), 
-                    (AccountAdminResponseDto)AccountMapper.entityToAdminResponse(givenAccountEntityUser().orElseThrow()));
-            assertEquals(expectedList, accountService.getAll());
-            verify(accountRepository, times(1)).findAll();
+        void testGetBy() {
+
+            final int page = 0;
+
+            final int size = 10;
+
+            when(accountRepository.findBy(any(Pageable.class))).thenAnswer(anser -> {
+
+                Account accountOne = givenAccountEntityAdmin().orElseThrow();
+
+                Account accountTwo = givenAccountEntityUser().orElseThrow();
+
+                List<Account> entityList = new ArrayList<>();
+
+                entityList.add(accountOne);
+                entityList.add(accountTwo);
+
+                return new PageImpl<>(entityList);
+            });
+
+            List<AccountAdminResponseDto> expectedResponseList = accountService.getBy(page, size).getContent();
+
+            assertThat(expectedResponseList).hasSize(2);
+
+            verify(accountRepository, times(1)).findBy(any(Pageable.class));
         }
 
         @Test


### PR DESCRIPTION
This PR adds pagination to view all accounts functionality/endpoint

### Endpoint affected: GET `api/accounts`

URI parameters `page` and `size` added.

### Previous JSON response example:

```json
[
  {
    "email": "string",
    "personId": 0,
    "id": 0,
    "roles": [
      {
        "id": 0,
        "name": "string"
      }
    ],
    "audit": {
      "createdAt": "2019-08-24T14:15:22Z",
      "updatedAt": "2019-08-24T14:15:22Z",
      "enabled": true
    }
  }
]
```

### New JSON response example:

```json
{
  "page": {
    "size": 0,
    "number": 0,
    "totalElements": 0,
    "totalPages": 0
  },
  "content": [
    {
      "email": "string",
      "personId": 0,
      "id": 0,
      "roles": [
        {
          "id": 0,
          "name": "string"
        }
      ],
      "audit": {
        "createdAt": "2019-08-24T14:15:22Z",
        "updatedAt": "2019-08-24T14:15:22Z",
        "enabled": true
      }
    }
  ]
}
```

### Solved: 
Resolves #199

>[!NOTE]
> Tests affected by this feature fix were reworked.
