### PR TITLE
Add missing view all persons endpoint pagination

### DIFF
--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonController.java
@@ -3,6 +3,7 @@ package com.crhistianm.springboot.gallo.springboot_gallo.person;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.web.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -44,8 +46,11 @@ public class PersonController {
             @ApiResponse(responseCode = "404",content = {}),
         }
     )
-    public ResponseEntity<List<PersonResponseDto>> viewAll(){
-        return ResponseEntity.ok(personService.getAll());
+    public ResponseEntity<PagedModel<PersonResponseDto>> viewBy(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size 
+    ) {
+        return ResponseEntity.ok(personService.getBy(page, size));
     }
     
     @GetMapping("/{id}")

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonRepository.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonRepository.java
@@ -1,13 +1,13 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.person;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 
 interface PersonRepository extends CrudRepository <Person, Long> {
 
     boolean existsByPhoneNumber(String phoneNumber);
 
-    List<Person> findAll();
-    
+    Page<Person> findBy(Pageable pageable);
+
 }

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonService.java
@@ -5,6 +5,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.account.IdentityVerificationService;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.web.PagedModel;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,10 +67,11 @@ class PersonService {
     }
 
     @Transactional(readOnly = true)
-    List<PersonResponseDto> getAll() {
-        List<PersonResponseDto> personList = personRepository.findAll().stream().map(p -> PersonMapper.entityToResponse(p)).collect(Collectors.toList());
-        return personList;
-    }
+    PagedModel<PersonResponseDto> getBy(int page, int size) {
+        Page<PersonResponseDto> personPage = personRepository.findBy(PageRequest.of(page, size))
+            .map(PersonMapper::entityToResponse);
 
+        return new PagedModel<PersonResponseDto>(personPage);
+    }
     
 }

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonControllerTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonControllerTest.java
@@ -11,6 +11,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.web.PagedModel;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -19,6 +21,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -132,18 +135,39 @@ class PersonControllerTest {
         }
 
         @Test
-        void testViewAll() throws Exception {
-            when(personService.getAll()).thenReturn(List.of(PersonMapper.entityToResponse(givenPersonEntityOne().orElseThrow()), PersonMapper.entityToResponse(givenPersonEntityTwo().orElseThrow())));
+        void testViewBy() throws Exception {
+            doAnswer(invo -> {
+                List<PersonResponseDto> dtoList = new ArrayList<>();
+
+                PersonResponseDto dtoOne = new PersonResponseDto();
+                PersonResponseDto dtoTwo = new PersonResponseDto();
+
+                dtoOne.setId(1L);
+                dtoTwo.setId(2L);
+
+                dtoOne.setFirstName("Crhistian");
+                dtoTwo.setFirstName("Erick");
+
+                dtoOne.setPhoneNumber("55896144");
+                dtoTwo.setPhoneNumber("4444444");
+
+                dtoList.add(dtoOne);
+                dtoList.add(dtoTwo);
+
+                PageImpl<PersonResponseDto> dtoPage = new PageImpl<>(dtoList);
+
+                return new PagedModel<PersonResponseDto>(dtoPage);
+            }).when(personService).getBy(anyInt(), anyInt());
 
             mockMvc.perform(get("/api/persons"))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].id").value(1L))
-                .andExpect(jsonPath("$[1].id").value(2L))
-                .andExpect(jsonPath("$[0].firstName").value("Crhistian"))
-                .andExpect(jsonPath("$[1].firstName").value("Erick"))
-                .andExpect(jsonPath("$[1].phoneNumber").value("55896144"))
-                .andExpect(jsonPath("$[0].phoneNumber").value("4444444"));
+                .andExpect(jsonPath("$.content[0].id").value(1L))
+                .andExpect(jsonPath("$.content[1].id").value(2L))
+                .andExpect(jsonPath("$.content[0].firstName").value("Crhistian"))
+                .andExpect(jsonPath("$.content[1].firstName").value("Erick"))
+                .andExpect(jsonPath("$.content.[1].phoneNumber").value("4444444"))
+                .andExpect(jsonPath("$.content[0].phoneNumber").value("55896144"));
         }
 
         @Test

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonServiceUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonServiceUnitTest.java
@@ -6,6 +6,7 @@ import static com.crhistianm.springboot.gallo.springboot_gallo.person.PersonData
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,6 +15,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.account.IdentityVerificationService;
+
+import org.aspectj.runtime.internal.PerObjectMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,6 +24,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.shared.FieldInfoErrorBuilder;
 import com.crhistianm.springboot.gallo.springboot_gallo.shared.exception.NotFoundException;
@@ -113,12 +119,30 @@ class PersonServiceUnitTest {
         }
 
         @Test
-        void testGetAll(){
-            when(personRepository.findAll()).thenReturn(List.of(givenPersonEntityOne().orElseThrow(), givenPersonEntityTwo().orElseThrow()));
+        void testGetBy(){
+            doAnswer(invo -> {
+                List<Person> entityList = new ArrayList<>();
 
-            List<PersonResponseDto> expectedList = List.of(PersonMapper.entityToResponse(givenPersonEntityOne().orElseThrow()), PersonMapper.entityToResponse(givenPersonEntityTwo().orElseThrow()));
-            assertEquals(expectedList, personService.getAll());
-            verify(personRepository, times(1)).findAll();
+                Person personOne = new PersonBuilder().id(1L).build();
+                Person personTwo = new PersonBuilder().id(2L).build();
+
+                entityList.add(personOne);
+                entityList.add(personTwo);
+
+                PageImpl<Person> personPageResponse = new PageImpl<>(entityList);
+
+                return personPageResponse;
+            }).when(personRepository).findBy(any(Pageable.class));
+
+            final int page = 0;
+
+            final int size = 10;
+
+            List<PersonResponseDto> expectedResponse = personService.getBy(page, size).getContent();
+
+            assertThat(expectedResponse).hasSize(2);
+
+            verify(personRepository, times(1)).findBy(eq(PageRequest.of(page, size)));
         }
 
         @Test


### PR DESCRIPTION
This PR adds pagination to view all persons functionality/endpoint

### Endpoint affected: GET `api/person`

URI parameters `page` and `size` added.

### Previous JSON response example:

```json
[
    {
    "id": 0,
        "firstName": "string",
        "lastName": "string",
        "phoneNumber": "string",
        "birthDate": "2019-08-24",
        "gender": "string",
        "height": 0.1,
        "weight": 0.1
    }
]
```

### New JSON response example:

```json
{
  "page": {
    "size": 0,
    "number": 0,
    "totalElements": 0,
    "totalPages": 0
  },
  "content": [
    {
      "id": 0,
      "firstName": "string",
      "lastName": "string",
      "phoneNumber": "string",
      "birthDate": "2019-08-24",
      "gender": "string",
      "height": 0.1,
      "weight": 0.1
    }
  ]
}
```

### Solved: 
Resolves #200

>[!NOTE]
> Tests affected by this feature fix were reworked.
