### PR TITLE
Add cache responses to person module

### DIFF
--- a/backend/compose.yml
+++ b/backend/compose.yml
@@ -1,0 +1,6 @@
+services:
+  redis:
+    image: redis:7.4-alpine
+    ports:
+      - "6379:6379"
+

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -27,7 +27,8 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>17</java.version>
+        <java.version>17</java.version>
+        <testcontainers.version>1.21.4</testcontainers.version>
 	</properties>
 	<dependencies>
 
@@ -80,6 +81,16 @@
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -34,6 +34,14 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-docker-compose</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/SpringbootGalloApplication.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/SpringbootGalloApplication.java
@@ -2,8 +2,11 @@ package com.crhistianm.springboot.gallo.springboot_gallo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.cache.annotation.EnableCaching;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = RedisAutoConfiguration.class)
+@EnableCaching
 public class SpringbootGalloApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonResponseDto.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonResponseDto.java
@@ -2,7 +2,9 @@ package com.crhistianm.springboot.gallo.springboot_gallo.person;
 
 import java.time.LocalDate;
 
-class PersonResponseDto {
+import com.crhistianm.springboot.gallo.springboot_gallo.shared.ResponseDto;
+
+class PersonResponseDto implements ResponseDto {
 
     private Long id;
 

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonService.java
@@ -62,7 +62,7 @@ class PersonService {
 
     @Transactional
     PersonResponseDto update(Long id, PersonRequestDto personDto) {
-        personRepository.findById(id).orElseThrow(() -> new NotFoundException(Person.class));
+        if(!personRepository.existsById(id)) throw new NotFoundException(Person.class);
         personValidator.validateRequest(id, personDto);
         Person person = PersonMapper.requestToEntity(personDto);
 
@@ -87,7 +87,7 @@ class PersonService {
 
     @Transactional(readOnly = true)
     PersonResponseDto getById(Long id) {
-        Person person = personRepository.findById(id).orElseThrow(() -> new NotFoundException(Person.class));
+        if(!personRepository.existsById(id)) throw new NotFoundException(Person.class);
         identityService.validateUserAllowanceByPersonId(id).ifPresent(f -> {
             throw new ValidationServiceException(new ArrayList<>(List.of(f)));
         });
@@ -98,13 +98,17 @@ class PersonService {
             .keyId(id)
             .cache(cacheManager.getCache(PERSON))
             .responseType(PersonResponseDto.class)
-            .onMissDo(() -> PersonMapper.entityToResponse(person))
+            .onMissDo(() -> {
+                Person personEntity = personRepository.findById(id).get();
+                return PersonMapper.entityToResponse(personEntity);
+            })
             .build();
 
         return CacheHandlingUtils.getOrCacheResponse(cacheContext);
     }
 
     @Transactional(readOnly = true)
+    //This is not cached as it is only for admins
     PagedModel<PersonResponseDto> getBy(int page, int size) {
         Page<PersonResponseDto> personPage = personRepository.findBy(PageRequest.of(page, size))
             .map(PersonMapper::entityToResponse);

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonService.java
@@ -6,6 +6,10 @@ import java.util.stream.Collectors;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.account.IdentityVerificationService;
 
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -13,8 +17,12 @@ import org.springframework.data.web.PagedModel;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.crhistianm.springboot.gallo.springboot_gallo.shared.cache.CacheHandlingUtils;
+import com.crhistianm.springboot.gallo.springboot_gallo.shared.cache.CacheResponseContext;
 import com.crhistianm.springboot.gallo.springboot_gallo.shared.exception.NotFoundException;
 import com.crhistianm.springboot.gallo.springboot_gallo.shared.exception.ValidationServiceException;
+
+import static com.crhistianm.springboot.gallo.springboot_gallo.shared.cache.CacheModule.PERSON;
 
 @Service
 class PersonService {
@@ -25,17 +33,31 @@ class PersonService {
 
     private final IdentityVerificationService identityService;
 
-    PersonService(PersonRepository personRepository, PersonValidator personValidator, IdentityVerificationService identityService){
-        this.personRepository = personRepository;
-        this.personValidator = personValidator;
-        this.identityService = identityService;
-    }
+    private final CacheManager cacheManager;
+
+    PersonService
+        (
+         PersonRepository personRepository,
+         PersonValidator personValidator,
+         IdentityVerificationService identityService,
+         CacheManager cacheManager
+        ){
+            this.personRepository = personRepository;
+            this.personValidator = personValidator;
+            this.identityService = identityService;
+            this.cacheManager = cacheManager;
+        }
 
     @Transactional
     PersonResponseDto save(PersonRequestDto personDto) {
         personValidator.validateRequest(null, personDto);
         Person person = PersonMapper.requestToEntity(personDto);
-        return PersonMapper.entityToResponse(personRepository.save(person));
+
+        PersonResponseDto responseDto = PersonMapper.entityToResponse(personRepository.save(person));
+
+        cacheManager.getCache(PERSON).put(responseDto.getId(), responseDto);
+
+        return responseDto;
     }
 
     @Transactional
@@ -43,11 +65,17 @@ class PersonService {
         personRepository.findById(id).orElseThrow(() -> new NotFoundException(Person.class));
         personValidator.validateRequest(id, personDto);
         Person person = PersonMapper.requestToEntity(personDto);
+
         person.setId(id);
-        return PersonMapper.entityToResponse(personRepository.save(person));
+
+        PersonResponseDto responseDto = PersonMapper.entityToResponse(personRepository.save(person));
+
+        cacheManager.getCache(PERSON).put(responseDto.getId(), responseDto);
+        return responseDto;
     }
 
     @Transactional
+    @CacheEvict(value = PERSON, key = "#id")
     PersonResponseDto delete(Long id) {
         Person person = personRepository.findById(id).orElseThrow(() -> new NotFoundException(Person.class));
         identityService.validateUserAllowanceByPersonId(id).ifPresent(f -> {
@@ -63,7 +91,17 @@ class PersonService {
         identityService.validateUserAllowanceByPersonId(id).ifPresent(f -> {
             throw new ValidationServiceException(new ArrayList<>(List.of(f)));
         });
-        return PersonMapper.entityToResponse(person);
+
+        CacheResponseContext<PersonResponseDto> cacheContext = CacheResponseContext
+            //This reference is needed to specify the type to the generic builder
+            .<PersonResponseDto>builder()
+            .keyId(id)
+            .cache(cacheManager.getCache(PERSON))
+            .responseType(PersonResponseDto.class)
+            .onMissDo(() -> PersonMapper.entityToResponse(person))
+            .build();
+
+        return CacheHandlingUtils.getOrCacheResponse(cacheContext);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/ResponseDto.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/ResponseDto.java
@@ -1,0 +1,3 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.shared;
+
+public interface ResponseDto {}

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/cache/CacheHandlingUtils.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/cache/CacheHandlingUtils.java
@@ -1,0 +1,27 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.shared.cache;
+
+import org.springframework.cache.Cache;
+
+import com.crhistianm.springboot.gallo.springboot_gallo.shared.ResponseDto;
+
+import static java.util.Objects.nonNull;
+
+public class CacheHandlingUtils {
+
+    public static <T extends ResponseDto> T getOrCacheResponse(CacheResponseContext<T> context) {
+        final Cache cache = context.getCache();
+        if(nonNull(cache)) {
+            T cachedResponse = cache.get(context.getKeyId(), context.getResponseType());
+            if(nonNull(cachedResponse)) return cachedResponse;
+        }
+
+        T responseDto = context.getOnMissDo().get();
+
+        if(nonNull(cache)) cache.put(context.getKeyId(), responseDto);
+
+        return responseDto;
+    }
+    
+}
+
+

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/cache/CacheModule.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/cache/CacheModule.java
@@ -1,0 +1,5 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.shared.cache;
+
+public class CacheModule {
+    public static final String PERSON = "PERSON";
+}

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/cache/CacheResponseContext.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/cache/CacheResponseContext.java
@@ -1,0 +1,95 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.shared.cache;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Supplier;
+
+import org.springframework.cache.Cache;
+
+import com.crhistianm.springboot.gallo.springboot_gallo.shared.ResponseDto;
+
+public final class CacheResponseContext<T extends ResponseDto>{
+
+    private final Long keyId;
+
+    private final Cache cache;
+
+    private final Class<T> responseType;
+
+    private final Supplier<T> onMissDo;
+
+    public Long getKeyId() { return this.keyId; }
+
+    public Cache getCache() { return this.cache; }
+
+    public Class<T> getResponseType() { return this.responseType; }
+
+    public Supplier<T> getOnMissDo(){ return this.onMissDo; }
+
+    private CacheResponseContext
+    (
+     Long keyId,
+     Cache cache,
+     Class<T> responseType,
+     Supplier<T> onMissDo
+    ) {
+        this.keyId = keyId;
+        this.cache = cache;
+        this.responseType = responseType;
+        this.onMissDo = onMissDo;
+    }
+
+    public static <T extends ResponseDto> Builder<T> builder() {
+        return new Builder<T>();
+    }
+
+    public static class Builder<T extends ResponseDto>{
+
+        private Long keyId;
+
+        private Cache cache;
+
+        private Class<T> responseType;
+
+        private Supplier<T> onMissDo;
+
+        private Builder() {}
+
+        public Builder<T> cache(final Cache cache){
+            this.cache = cache;
+            return this;
+        }
+
+        public Builder<T> keyId(final Long keyId) {
+            this.keyId = keyId;
+            return this;
+        }
+
+        public Builder<T> responseType(final Class<T> responseType) {
+            this.responseType = responseType;
+            return this;
+        }
+
+        public Builder<T> onMissDo(Supplier<T> onMissDo) {
+            this.onMissDo = onMissDo;
+            return this;
+        }
+
+        public CacheResponseContext<T> build() {
+            requireNonNull(this.responseType);
+            requireNonNull(this.onMissDo);
+            requireNonNull(this.keyId);
+            return new CacheResponseContext<>
+                (
+                 this.keyId,
+                 this.cache,
+                 this.responseType,
+                 this.onMissDo
+                );
+        }
+
+
+    }
+
+
+}

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/config/RedisConfig.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/config/RedisConfig.java
@@ -1,0 +1,67 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.shared.config;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import static com.crhistianm.springboot.gallo.springboot_gallo.shared.cache.CacheModule.PERSON;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+
+@ConditionalOnProperty(prefix = "spring", name = "cache.type", havingValue = "redis")
+@Import(value = RedisAutoConfiguration.class)
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory, ObjectMapper objectMapper) {
+        ObjectMapper redisObjectMapper = objectMapper.copy();
+        redisObjectMapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder()
+                .allowIfSubType("com.crhistianm.springboot.gallo")
+                .build(),
+                ObjectMapper.DefaultTyping.NON_FINAL
+        );
+
+        RedisSerializer<Object> valueSerializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper);
+
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
+            .defaultCacheConfig(Thread.currentThread().getContextClassLoader())
+            .entryTtl(Duration.ofMinutes(10))
+            .disableCachingNullValues()
+            .serializeKeysWith(RedisSerializationContext
+                    .SerializationPair
+                    .fromSerializer(new StringRedisSerializer()))
+            .serializeValuesWith(RedisSerializationContext
+                    .SerializationPair
+                    .fromSerializer(valueSerializer));
+
+
+        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+
+        cacheConfigurations.put(PERSON, redisCacheConfiguration.entryTtl(Duration.ofHours(1)));
+
+        RedisCacheManager redisCacheManager = RedisCacheManager
+            .builder(connectionFactory)
+            .cacheDefaults(redisCacheConfiguration)
+            .withInitialCacheConfigurations(cacheConfigurations)
+            .build();
+
+        return redisCacheManager;
+    }
+
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,3 +8,6 @@ spring.jpa.show-sql=true
 server.forward-headers-strategy=framework
 springdoc.api-docs.server-url=https://gallospring.duckdns.org
 springdoc.default-produces-media-type=application/json;charset=UTF-8
+spring.data.redis.host=${REDIS_HOST}
+spring.data.redis.port=${REDIS_PORT}
+spring.cache.type=redis

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonControllerTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonControllerTest.java
@@ -10,11 +10,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.web.PagedModel;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -41,6 +43,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 //remove security filters as is not needed in these tests
 @AutoConfigureMockMvc(addFilters = false)
 class PersonControllerTest {
+
+    @MockitoBean
+    private CacheManager cacheManager;
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonServiceCacheTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonServiceCacheTest.java
@@ -1,0 +1,209 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.person;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+
+import com.crhistianm.springboot.gallo.springboot_gallo.account.IdentityVerificationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+//Enable H2 
+@TestPropertySource(properties = {
+"spring.datasource.url=jdbc:h2:mem:testdb",
+"spring.datasource.driverClassName=org.h2.Driver",
+"spring.datasource.username=sa",
+"spring.datasource.password=password",
+"spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+"spring.docker.compose.enabled=false"
+})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc(addFilters = false)
+@Testcontainers
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+class PersonServiceCacheTest {
+
+    @Container
+    @ServiceConnection
+    private static GenericContainer<?> redis = new GenericContainer(DockerImageName.parse("redis:7.4-alpine"))
+        .withExposedPorts(6379);
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    //This is only used for using verify with Mockito. But both are the same bean
+    @MockitoSpyBean
+    private PersonRepository personRepositorySpy;
+
+    @Autowired
+    private PersonRepository personRepository;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @MockitoBean
+    private PersonValidator personValidator;
+
+    @MockitoBean
+    private IdentityVerificationService identityVerificationService;
+
+    @AfterEach
+    void setUp() {
+        personRepository.deleteAll();
+        cacheManager.getCache("PERSON").clear();
+    }
+
+    @Test
+    void shouldCacheResponseWhenPersonIsCreated() throws Exception {  
+        final String firstName = "testname";
+        final String lastName = "testlastname";
+        final String phoneNumber = "992222";
+        final LocalDate birthDate = LocalDate.of(2010, 9, 27);
+        final String gender = "M";
+
+        final Double height = null;
+        final Double weight = null;
+
+
+        PersonRequestDto requestDto = new PersonRequestDto(firstName, lastName, phoneNumber, birthDate, gender, height, weight);
+
+        MvcResult result = mockMvc.perform(post("/api/persons")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isCreated())
+            .andReturn();
+
+        PersonResponseDto expectedResponse = objectMapper.readValue(result.getResponse().getContentAsString(), PersonResponseDto.class);
+
+        Long savedPersonId = expectedResponse.getId();
+
+        Cache cache = cacheManager.getCache("PERSON");
+
+        assertThat(cache).isNotNull();
+
+        PersonResponseDto cachedResponseDto = cache.get(savedPersonId, PersonResponseDto.class);
+
+        assertThat(cachedResponseDto).isNotNull();
+        assertThat(cachedResponseDto).isEqualTo(expectedResponse);
+
+    }
+
+    @Test 
+    @Sql(value = {"/personinserts.sql"}, executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+    void shouldCacheResponseWhenPersonIsUpdated() throws Exception {
+
+        final Long personId = 1L;
+
+        final String firstName = "Crhistian";
+        final String lastName = "modified";
+        final String phoneNumber = "111222333";
+        final LocalDate birthDate = LocalDate.of(2000, 1, 01);
+        final String gender = "M";
+
+        final Double height = 1.74;
+        final Double weight = 80.0;
+
+        PersonRequestDto requestDto = new PersonRequestDto(firstName, lastName, phoneNumber, birthDate, gender, height, weight);
+
+        mockMvc.perform(put("/api/persons/" + personId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        Cache cache = cacheManager.getCache("PERSON");
+
+        assertThat(cache).isNotNull();
+
+        PersonResponseDto responseDto = cache.get(personId, PersonResponseDto.class);
+
+        assertThat(responseDto).isNotNull();
+    }
+
+    @Test
+    @Sql(value = {"/personinserts.sql"}, executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+    void shouldCacheResponseWhenPersonIsRequested() throws Exception {
+        final Long personId = 1L;
+
+        mockMvc.perform(get("/api/persons/" + personId))
+            .andExpect(status().isOk());
+
+        Cache cache = cacheManager.getCache("PERSON");
+
+        PersonResponseDto cachedResponse = cache.get(personId, PersonResponseDto.class);
+
+        assertThat(cachedResponse).isNotNull();
+
+        MvcResult result =  mockMvc.perform(get("/api/persons/" + personId))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        PersonResponseDto requestResponse = objectMapper
+            .readValue(result.getResponse().getContentAsString(), PersonResponseDto.class);
+
+        assertThat(cachedResponse).isEqualTo(requestResponse);
+
+        verify(personRepositorySpy, times(2)).existsById(eq(personId));
+        verify(identityVerificationService, times(2)).validateUserAllowanceByPersonId(eq(personId));
+        verify(personRepositorySpy, times(1)).findById(eq(personId));
+        verifyNoMoreInteractions(personRepositorySpy);
+    }
+
+    @Test
+    @Sql(value = {"/personinserts.sql"}, executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+    void shouldRemoveCachedResponseWhenPersonIsDeleted() throws Exception {
+        final Long personId = 1L;
+
+        mockMvc.perform(get("/api/persons/" + personId))
+            .andExpect(status().isOk());
+
+        PersonResponseDto cachedResponse = cacheManager.getCache("PERSON").get(personId, PersonResponseDto.class);
+
+        assertThat(cachedResponse).isNotNull();
+
+        mockMvc.perform(delete("/api/persons/" + personId))
+            .andExpect(status().isOk());
+
+        cachedResponse = cacheManager.getCache("PERSON").get(personId, PersonResponseDto.class);
+
+        assertThat(cachedResponse).isNull();
+    }
+
+}

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonServiceUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonServiceUnitTest.java
@@ -24,9 +24,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.CacheManager;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.cache.Cache;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.shared.FieldInfoErrorBuilder;
 import com.crhistianm.springboot.gallo.springboot_gallo.shared.exception.NotFoundException;
@@ -38,6 +40,12 @@ class PersonServiceUnitTest {
 
     @Mock
     PersonValidator personValidator;
+
+    @Mock
+    CacheManager cacheManager;
+
+    @Mock
+    Cache cache;
 
     @Mock
     PersonRepository personRepository;
@@ -55,7 +63,8 @@ class PersonServiceUnitTest {
     class CreateModuleTest {
 
         @BeforeEach
-        void setUp() {
+        void setUp() { 
+            lenient().when(cacheManager.getCache(anyString())).thenReturn(cache);
 
             lenient().doAnswer(invo -> {
                 return invo.getArgument(0, Person.class);
@@ -105,6 +114,7 @@ class PersonServiceUnitTest {
 
         @BeforeEach
         void setUp(){
+            lenient().when(cacheManager.getCache(anyString())).thenReturn(cache);
             lenient().doAnswer(invo -> {
                 FieldInfoError field = null;
                 if(invo.getArgument(0, Long.class).equals(120L)) field = new FieldInfoErrorBuilder().name("identity").build();
@@ -112,10 +122,15 @@ class PersonServiceUnitTest {
             }).when(identityVerificationService).validateUserAllowanceByPersonId(anyLong());
             lenient().when(personRepository.findById(anyLong())).thenAnswer(invo -> {
                 Optional<Person> responseOptional = Optional.empty();
-                if(invo.getArgument(0, Long.class) == 1L) responseOptional = givenPersonEntityOne();
-                if(invo.getArgument(0, Long.class) == 120L) responseOptional = givenPersonEntityOne();
+                if(invo.getArgument(0, Long.class).equals(1L)) responseOptional = givenPersonEntityOne();
+                if(invo.getArgument(0, Long.class).equals(120L)) responseOptional = givenPersonEntityOne();
                 return responseOptional;
             });
+
+            lenient().doAnswer(invo -> {
+                final Long argId = invo.getArgument(0, Long.class);
+                return argId.equals(1L) || argId.equals(120L);
+            }).when(personRepository).existsById(anyLong());
         }
 
         @Test
@@ -150,6 +165,8 @@ class PersonServiceUnitTest {
             PersonResponseDto expectedPerson = PersonMapper.entityToResponse(givenPersonEntityOne().orElseThrow());
 
             assertEquals(expectedPerson, personService.getById(1L));
+
+            verify(personRepository, times(1)).existsById(anyLong());
             verify(personRepository, times(1)).findById(anyLong());
         }
 
@@ -158,7 +175,7 @@ class PersonServiceUnitTest {
             assertThrows(NotFoundException.class, () -> {
                 personService.getById(2L);
             });
-            verify(personRepository, times(1)).findById(anyLong());
+            verify(personRepository, times(1)).existsById(anyLong());
         }
 
         @Test
@@ -170,6 +187,8 @@ class PersonServiceUnitTest {
 
             assertThat(field).isNotNull();
             assertThat(field).extracting(FieldInfoError::getName).isEqualTo("identity");
+
+            verify(personRepository, times(1)).existsById(anyLong());
         }
 
     }
@@ -181,11 +200,10 @@ class PersonServiceUnitTest {
 
         @BeforeEach
         void setUp(){
-            when(personRepository.findById(anyLong())).thenAnswer(invo -> {
-                if(invo.getArgument(0, Long.class) == 1L){
-                    return Optional.of(new Person());
-                }
-                return Optional.empty();
+            lenient().when(cacheManager.getCache(anyString())).thenReturn(cache);
+
+            when(personRepository.existsById(anyLong())).thenAnswer(invo -> {
+                return invo.getArgument(0, Long.class).equals(1L);
             });
 
             lenient().doAnswer(args -> {
@@ -196,8 +214,6 @@ class PersonServiceUnitTest {
             }).when(personValidator).validateRequest(anyLong(), any(PersonRequestDto.class));
         }
         
-
-
         @Test
         void testUpdate(){
             requestDto = givenPersonRequestDtoOne().orElseThrow();
@@ -221,9 +237,8 @@ class PersonServiceUnitTest {
 
             assertEquals(expectedResponse, actualResponse);
 
-            verify(personRepository, times(1)).findById(anyLong());
+            verify(personRepository, times(1)).existsById(anyLong());
             verify(personRepository, times(1)).save(any(Person.class));
-
         }
 
         @Test
@@ -241,7 +256,8 @@ class PersonServiceUnitTest {
             assertThrows(NotFoundException.class, () ->{
                 personService.update(2L, requestDto);
             });
-            verify(personRepository, times(1)).findById(anyLong());
+            verify(personRepository, times(1)).existsById(anyLong());
+            verifyNoMoreInteractions(personRepository);
         }
 
         @Test
@@ -259,7 +275,8 @@ class PersonServiceUnitTest {
 
             assertThatExceptionOfType(ValidationServiceException.class)
                 .isThrownBy(() -> personService.update(1L, requestDto));
-            verify(personRepository, times(1)).findById(eq(1L));
+
+            verify(personRepository, times(1)).existsById(eq(1L));
             verifyNoMoreInteractions(personRepository);
         }
         
@@ -275,12 +292,14 @@ class PersonServiceUnitTest {
                 if(invo.getArgument(0, Long.class).equals(120L)) field = new FieldInfoErrorBuilder().name("identity").build();
                 return Optional.ofNullable(field);
             }).when(identityVerificationService).validateUserAllowanceByPersonId(anyLong());
-            when(personRepository.findById(anyLong())).thenAnswer(invo ->{
+
+            lenient().when(personRepository.findById(anyLong())).thenAnswer(invo ->{
                 Optional<Person> personDb = Optional.empty();
-                if(invo.getArgument(0, Long.class) == 1L) personDb = givenPersonEntityOne();
-                if(invo.getArgument(0, Long.class) == 120L) personDb = givenPersonEntityOne();
+                if(invo.getArgument(0, Long.class).equals(1L)) personDb = givenPersonEntityOne();
+                if(invo.getArgument(0, Long.class).equals(120L)) personDb = givenPersonEntityOne();
                 return personDb;
             });
+
         }
 
         @Test
@@ -303,7 +322,7 @@ class PersonServiceUnitTest {
             FieldInfoError field = null;
 
             field = assertThatExceptionOfType(ValidationServiceException.class)
-                .isThrownBy(() -> personService.getById(120L)).actual().getFieldErrors().get(0);
+                .isThrownBy(() -> personService.delete(120L)).actual().getFieldErrors().get(0);
 
             assertThat(field).isNotNull();
             assertThat(field).extracting(FieldInfoError::getName).isEqualTo("identity");

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/CacheHandlingUtilsTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/CacheHandlingUtilsTest.java
@@ -1,0 +1,116 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.shared;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+
+import com.crhistianm.springboot.gallo.springboot_gallo.shared.cache.CacheHandlingUtils;
+import com.crhistianm.springboot.gallo.springboot_gallo.shared.cache.CacheResponseContext;
+
+@ExtendWith(MockitoExtension.class)
+public class CacheHandlingUtilsTest {
+
+    @Mock
+    private Cache cache;
+
+    //Testeas esto y renameas la branch a perf/person-cache y haces la PR. Despues tenes el stash para una nueva PR de account cache
+    private class TestDto implements ResponseDto {
+
+        private Long id;
+
+        private String example;
+
+        public TestDto(String example, Long id) { this.example = example; this.id = id; }
+
+        public String getExample() { return example; }
+
+    }
+
+    private CacheResponseContext<TestDto> cacheContext;
+
+    private final Long responseId = 1L;
+
+    @BeforeEach
+    void setUp(){ clearInvocations(cache); }
+
+    @Test
+    void shouldReturnCachedResponseWhenCacheHits(){
+        final String example = "cached";
+        TestDto responseDto = new TestDto(example, responseId);
+
+        doReturn(responseDto).when(cache).get(anyLong(), eq(TestDto.class));
+
+        cacheContext = CacheResponseContext
+            .<TestDto>builder()
+            .responseType(TestDto.class)
+            .keyId(responseId)
+            .cache(cache)
+            .onMissDo(() -> null)
+            .build();
+
+
+        TestDto expectedResponse = CacheHandlingUtils.getOrCacheResponse(cacheContext);
+
+        assertThat(expectedResponse).extracting(TestDto::getExample).isEqualTo("cached");
+
+        verify(cache, times(1)).get(eq(responseId), eq(TestDto.class));
+        verifyNoMoreInteractions(cache);
+    }
+
+    @Test
+    void shouldCacheAndReturnSupplierResponseWhenCacheMisses(){
+        final String example = "toCache";
+        TestDto responseDto = new TestDto(example, responseId);
+
+        doReturn(null).when(cache).get(anyLong(), eq(TestDto.class));
+
+        cacheContext = CacheResponseContext
+            .<TestDto>builder()
+            .responseType(TestDto.class)
+            .keyId(responseId)
+            .cache(cache)
+            .onMissDo(() -> responseDto)
+            .build();
+
+
+        TestDto expectedResponse = CacheHandlingUtils.getOrCacheResponse(cacheContext);
+
+        assertThat(expectedResponse).extracting(TestDto::getExample).isEqualTo("toCache");
+
+        verify(cache, times(1)).get(eq(responseId), eq(TestDto.class));
+        verify(cache, times(1)).put(eq(responseId), eq(responseDto));
+    }
+
+    @Test
+    void shouldReturnAndReturnSupplierResponseWhenCacheIsNull() {
+        final String example = "supplier";
+        TestDto responseDto = new TestDto(example, responseId);
+
+        cacheContext = CacheResponseContext
+            .<TestDto>builder()
+            .responseType(TestDto.class)
+            .keyId(responseId)
+            .cache(null)
+            .onMissDo(() -> responseDto)
+            .build();
+
+        TestDto expectedResponse = CacheHandlingUtils.getOrCacheResponse(cacheContext);
+
+        assertThat(expectedResponse).extracting(TestDto::getExample).isEqualTo("supplier");
+
+    }
+
+
+}

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/security/SpringEndpointSecurityTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/security/SpringEndpointSecurityTest.java
@@ -17,19 +17,24 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.shared.config.JacksonConfig;
+import com.crhistianm.springboot.gallo.springboot_gallo.shared.config.RedisConfig;
 import com.crhistianm.springboot.gallo.springboot_gallo.account.AccountUserDetailsService;
 import com.crhistianm.springboot.gallo.springboot_gallo.refreshtoken.RefreshTokenService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -37,10 +42,10 @@ import com.jayway.jsonpath.JsonPath;
 
 import jakarta.validation.Validator;
 
-
 @SpringBootTest
 @AutoConfigureMockMvc
 @Import({SpringSecurityConfig.class, JacksonConfig.class})
+@TestPropertySource(properties = "spring.cache.type=none")
 class SpringEndpointSecurityTest {
 
     @Autowired
@@ -183,14 +188,14 @@ class SpringEndpointSecurityTest {
 
             @Test
             void testUpdateValidAuthority() throws Exception{
-                mockMvc.perform(put("/api/person/1")
+                mockMvc.perform(put("/api/persons/1")
                         .contentType(MediaType.APPLICATION_JSON).header("Authorization", prefixWithToken))
-                    .andExpect(status().isNotFound());
+                    .andExpect(status().isBadRequest());
             }
 
             @Test
             void testDeleteValidAuthority()throws Exception {
-                mockMvc.perform(delete("/api/person/1")
+                mockMvc.perform(delete("/api/persons/1")
                         .contentType(MediaType.APPLICATION_JSON).header("Authorization", prefixWithToken))
                     .andExpect(status().isNotFound());
             }


### PR DESCRIPTION
This PR implements Redis cache to person client user endpoints described as the following:

### Endpoints affected:

- PERSON POST `api/persons`

- PERSON GET `api/persons/{any ID}`

- PERSON DELETE `api/persons/{any ID}`

- PERSON PUT `api/persons/{any ID}`

>[!IMPORTANT]
> Administrator endpoints are not cached.

>[!NOTE]
> Tests for this PR implementation are included.
