### PR TITLE
Fix missing complete entity preload before persisting in person update endpoint

### DIFF
--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonService.java
@@ -62,13 +62,19 @@ class PersonService {
 
     @Transactional
     PersonResponseDto update(Long id, PersonRequestDto personDto) {
-        if(!personRepository.existsById(id)) throw new NotFoundException(Person.class);
+        Person dbEntity = personRepository.findById(id).orElseThrow(() -> new NotFoundException(Person.class));
+
         personValidator.validateRequest(id, personDto);
-        Person person = PersonMapper.requestToEntity(personDto);
 
-        person.setId(id);
+        dbEntity.setBirthDate(personDto.getBirthDate());
+        dbEntity.setHeight(personDto.getHeight());
+        dbEntity.setWeight(personDto.getWeight());
+        dbEntity.setGender(personDto.getGender());
+        dbEntity.setFirstName(personDto.getFirstName());
+        dbEntity.setLastName(personDto.getLastName());
+        dbEntity.setPhoneNumber(personDto.getPhoneNumber());
 
-        PersonResponseDto responseDto = PersonMapper.entityToResponse(personRepository.save(person));
+        PersonResponseDto responseDto = PersonMapper.entityToResponse(personRepository.save(dbEntity));
 
         cacheManager.getCache(PERSON).put(responseDto.getId(), responseDto);
         return responseDto;

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonServiceUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonServiceUnitTest.java
@@ -202,8 +202,10 @@ class PersonServiceUnitTest {
         void setUp(){
             lenient().when(cacheManager.getCache(anyString())).thenReturn(cache);
 
-            when(personRepository.existsById(anyLong())).thenAnswer(invo -> {
-                return invo.getArgument(0, Long.class).equals(1L);
+            when(personRepository.findById(anyLong())).thenAnswer(invo -> {
+                Person person = null;
+                if(invo.getArgument(0, Long.class).equals(1L)) person = givenPersonEntityOne().get();
+                return Optional.ofNullable(person);
             });
 
             lenient().doAnswer(args -> {
@@ -237,7 +239,7 @@ class PersonServiceUnitTest {
 
             assertEquals(expectedResponse, actualResponse);
 
-            verify(personRepository, times(1)).existsById(anyLong());
+            verify(personRepository, times(1)).findById(anyLong());
             verify(personRepository, times(1)).save(any(Person.class));
         }
 
@@ -256,7 +258,7 @@ class PersonServiceUnitTest {
             assertThrows(NotFoundException.class, () ->{
                 personService.update(2L, requestDto);
             });
-            verify(personRepository, times(1)).existsById(anyLong());
+            verify(personRepository, times(1)).findById(anyLong());
             verifyNoMoreInteractions(personRepository);
         }
 
@@ -276,7 +278,7 @@ class PersonServiceUnitTest {
             assertThatExceptionOfType(ValidationServiceException.class)
                 .isThrownBy(() -> personService.update(1L, requestDto));
 
-            verify(personRepository, times(1)).existsById(eq(1L));
+            verify(personRepository, times(1)).findById(eq(1L));
             verifyNoMoreInteractions(personRepository);
         }
         


### PR DESCRIPTION
Adds missing complete entity retrieve from database emphasizing saving whole request with data integrity.

### Solved: 
Resolves #230