### PR TITLE
Add cache responses to account module

### DIFF
--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountResponseDto.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountResponseDto.java
@@ -1,7 +1,8 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.account;
 
+import com.crhistianm.springboot.gallo.springboot_gallo.shared.ResponseDto;
 
-abstract class AccountResponseDto {
+abstract class AccountResponseDto implements ResponseDto {
 
     protected String email;
 

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountService.java
@@ -129,7 +129,8 @@ class AccountService {
 
     @Transactional(readOnly = true)
     AccountResponseDto getById(Long id) {
-        Account account = accountRepository.findById(id).orElseThrow(() -> new NotFoundException(Account.class));
+        if(!accountRepository.existsById(id)) throw new NotFoundException(Account.class);
+
         accountValidator.validateByIdRequest(id);
 
         //Cache only for user role
@@ -140,11 +141,16 @@ class AccountService {
                 .keyId(id)
                 .cache(cacheManager.getCache(ACCOUNT))
                 .responseType(AccountUserResponseDto.class)
-                .onMissDo(() ->  (AccountUserResponseDto) AccountMapper.entityToResponse(account))
+                .onMissDo(() ->  {
+                    Account account = accountRepository.findById(id).get();
+                    return (AccountUserResponseDto) AccountMapper.entityToResponse(account);
+                })
                 .build();
 
             return CacheHandlingUtils.getOrCacheResponse(cacheContext);
         }
+
+        Account account = accountRepository.findById(id).get();
 
         return AccountMapper.entityToAdminResponse(account);
     }

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountService.java
@@ -4,6 +4,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.springframework.boot.autoconfigure.cache.CacheManagerCustomizers;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +18,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.person.Person;
+import static com.crhistianm.springboot.gallo.springboot_gallo.shared.cache.CacheModule.ACCOUNT;
+
+import com.crhistianm.springboot.gallo.springboot_gallo.shared.cache.CacheHandlingUtils;
+import com.crhistianm.springboot.gallo.springboot_gallo.shared.cache.CacheResponseContext;
 import com.crhistianm.springboot.gallo.springboot_gallo.shared.exception.NotFoundException;
 
 import jakarta.persistence.EntityManager;
@@ -32,6 +41,10 @@ class AccountService {
 
     private final EntityManager entityManager;
 
+    private final CacheManager cacheManager;
+
+    private final IdentityVerificationService identityVerificationService;
+
     AccountService
         (
          AccountRepository accountRepository,
@@ -39,7 +52,9 @@ class AccountService {
          PasswordEncoder passwordEncoder,
          AccountValidator accountValidator,
          AccountValidationService accountValidationService,
-         EntityManager entityManager
+         EntityManager entityManager,
+         CacheManager cacheManager,
+         IdentityVerificationService identityVerificationService 
         ){
             this.accountRepository = accountRepository;
             this.roleRepository = roleRepository;
@@ -47,6 +62,8 @@ class AccountService {
             this.accountValidator = accountValidator;
             this.accountValidationService = accountValidationService;
             this.entityManager = entityManager;
+            this.cacheManager = cacheManager;
+            this.identityVerificationService = identityVerificationService;
         }
 
     @Transactional
@@ -54,7 +71,6 @@ class AccountService {
         accountValidator.validateRequest(accountDto);
 
         Optional<Role> optionalRoleUser = roleRepository.findByName("ROLE_USER");
-
 
         Account account = AccountMapper.requestToEntity(accountDto);
 
@@ -68,12 +84,22 @@ class AccountService {
             optionalRoleAdmin.ifPresent(account::addRole);
         }
 
-        return accountValidationService.settleResponseType(accountRepository.save(account));
+        Account savedAccount = accountRepository.save(account);
+
+        AccountResponseDto responseDto = accountValidationService.settleResponseType(savedAccount);
+
+        //Cache only for user role
+        if(!identityVerificationService.isAdminAuthority()) {
+            cacheManager.getCache(ACCOUNT).put(savedAccount.getId(), responseDto);
+        }
+
+        return responseDto;
     }
 
     @Transactional
     AccountResponseDto update(Long id, AccountUpdateRequestDto accountDto) {
         Account account = accountRepository.findById(id).orElseThrow(() -> new NotFoundException(Account.class));
+
         accountValidator.validateUpdateRequest(id, accountDto);
 
         if(accountDto.getPersonId() != null) account.setPerson(entityManager.getReference(Person.class, accountDto.getPersonId()));
@@ -82,10 +108,18 @@ class AccountService {
         if(accountDto.getPassword() != null) account.setPassword(passwordEncoder.encode(accountDto.getPassword()));
         if(!accountDto.getRoles().isEmpty()) account.setRoles(accountDto.getRoles().stream().map(role -> RoleMapper.requestToEntity(role)).collect(Collectors.toList()));
 
-        return accountValidationService.settleResponseType(accountRepository.save(account));
+        AccountResponseDto responseDto = accountValidationService.settleResponseType(accountRepository.save(account));
+
+        //Cache only for user role
+        if(!identityVerificationService.isAdminAuthority()) {
+            cacheManager.getCache(ACCOUNT).put(id, responseDto);
+        }
+
+        return responseDto;
     }
 
     @Transactional
+    @CacheEvict(value = ACCOUNT, key = "#id")
     AccountResponseDto delete(Long id) {
         Account account = accountRepository.findById(id).orElseThrow(() -> new NotFoundException(Account.class));
         accountValidator.validateByIdRequest(id);
@@ -97,10 +131,26 @@ class AccountService {
     AccountResponseDto getById(Long id) {
         Account account = accountRepository.findById(id).orElseThrow(() -> new NotFoundException(Account.class));
         accountValidator.validateByIdRequest(id);
-        return accountValidationService.settleResponseType(account);
+
+        //Cache only for user role
+        if(!identityVerificationService.isAdminAuthority()) {
+
+            CacheResponseContext<AccountUserResponseDto> cacheContext = CacheResponseContext.
+                <AccountUserResponseDto>builder()
+                .keyId(id)
+                .cache(cacheManager.getCache(ACCOUNT))
+                .responseType(AccountUserResponseDto.class)
+                .onMissDo(() ->  (AccountUserResponseDto) AccountMapper.entityToResponse(account))
+                .build();
+
+            return CacheHandlingUtils.getOrCacheResponse(cacheContext);
+        }
+
+        return AccountMapper.entityToAdminResponse(account);
     }
 
     @Transactional(readOnly = true)
+    //This is not cached as it is only for admins
     PagedModel<AccountAdminResponseDto> getBy(int page, int size) {
         Page<AccountAdminResponseDto> accountPage = accountRepository.findBy(PageRequest.of(page, size))
             .map(account -> (AccountAdminResponseDto) AccountMapper.entityToAdminResponse(account));

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/cache/CacheModule.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/cache/CacheModule.java
@@ -2,4 +2,5 @@ package com.crhistianm.springboot.gallo.springboot_gallo.shared.cache;
 
 public class CacheModule {
     public static final String PERSON = "PERSON";
+    public static final String ACCOUNT = "ACCOUNT";
 }

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/config/RedisConfig.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/config/RedisConfig.java
@@ -18,6 +18,7 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import static com.crhistianm.springboot.gallo.springboot_gallo.shared.cache.CacheModule.PERSON;
+import static com.crhistianm.springboot.gallo.springboot_gallo.shared.cache.CacheModule.ACCOUNT;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
@@ -33,9 +34,11 @@ public class RedisConfig {
         redisObjectMapper.activateDefaultTyping(
                 BasicPolymorphicTypeValidator.builder()
                 .allowIfSubType("com.crhistianm.springboot.gallo")
+                .allowIfSubType("java.util")
                 .build(),
                 ObjectMapper.DefaultTyping.NON_FINAL
         );
+
 
         RedisSerializer<Object> valueSerializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper);
 
@@ -54,6 +57,7 @@ public class RedisConfig {
         Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
 
         cacheConfigurations.put(PERSON, redisCacheConfiguration.entryTtl(Duration.ofHours(1)));
+        cacheConfigurations.put(ACCOUNT, redisCacheConfiguration.entryTtl(Duration.ofHours(2)));
 
         RedisCacheManager redisCacheManager = RedisCacheManager
             .builder(connectionFactory)

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountServiceCacheTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountServiceCacheTest.java
@@ -1,0 +1,285 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.account;
+
+import static com.crhistianm.springboot.gallo.springboot_gallo.shared.cache.CacheModule.ACCOUNT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@TestPropertySource(properties = {
+"spring.datasource.url=jdbc:h2:mem:testdb",
+"spring.datasource.driverClassName=org.h2.Driver",
+"spring.datasource.username=sa",
+"spring.datasource.password=password",
+"spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+"spring.docker.compose.enabled=false"
+})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc(addFilters = false)
+@Testcontainers
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class AccountServiceCacheTest {
+
+    @Container
+    @ServiceConnection
+    private static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:7.4-alpine"))
+        .withExposedPorts(6379);
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @MockitoSpyBean
+    private AccountRepository spyAccountRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @MockitoBean
+    private AccountValidator accountValidator;
+
+    @MockitoBean
+    private IdentityVerificationService identityVerificationService;
+
+    @AfterEach
+    void doAfter() {
+        accountRepository.deleteAll();
+        cacheManager.getCache(ACCOUNT).clear();
+    }
+
+    @Test
+    @Sql(value = {"/personinserts.sql"}, executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+    void shouldCacheResponseWhenClientIsUserAuthorityAndAccountIsCreated() throws Exception {
+        final String email = "testemail@gmail.com";
+        final String password = "12345";
+        final Long personId = 1L;
+        final boolean admin = false;
+        AccountRequestDto requestDto = new AccountRequestDto(email, password, personId, admin);
+
+        doReturn(false).when(identityVerificationService).isAdminAuthority();
+
+        MvcResult result = mockMvc.perform(post("/api/accounts")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isCreated())
+            .andReturn();
+
+        AccountUserResponseDto expectedResponseDto = objectMapper.readValue(result.getResponse().getContentAsString(), AccountUserResponseDto.class);
+
+        Cache cache = cacheManager.getCache(ACCOUNT);
+
+        assertThat(cache).isNotNull();
+
+        //Retrieving from database as response dto does not contain account id
+        final Long savedAccountId = accountRepository.findAll().iterator().next().getId();
+
+        final AccountUserResponseDto cachedResponse = cache.get(savedAccountId, AccountUserResponseDto.class);
+
+        assertThat(cachedResponse).isNotNull();
+        assertThat(cachedResponse).isEqualTo(expectedResponseDto);
+    }
+
+    @Test
+    @Sql(value = {"/personinserts.sql"}, executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+    void shouldNotCacheResponseWhenClientIsAdminAuthorityAndAccountIsCreated() throws Exception {
+        final String email = "testemail@gmail.com";
+        final String password = "12345";
+        final Long personId = 1L;
+        final boolean admin = false;
+        AccountRequestDto requestDto = new AccountRequestDto(email, password, personId, admin);
+
+        doReturn(true).when(identityVerificationService).isAdminAuthority();
+
+        MvcResult result = mockMvc.perform(post("/api/accounts")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isCreated())
+            .andReturn();
+
+        final Long responseId = objectMapper.readValue(result.getResponse().getContentAsString(), AccountAdminResponseDto.class).getId();
+
+        assertThat(responseId).isNotNull();
+
+        Cache cache = cacheManager.getCache(ACCOUNT);
+
+        final AccountResponseDto cachedResponse = cache.get(responseId, AccountResponseDto.class);
+
+        assertThat(cachedResponse).isNull();
+    }
+
+    @Test
+    @Sql(value = {"/personinserts.sql", "/accountinserts.sql"}, executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+    void shouldCacheResponseWhenClientIsUserAuthorityAndIsUpdated() throws Exception {
+        doReturn(false).when(identityVerificationService).isAdminAuthority();
+
+        final Long accountId = 1L;
+        final String email = "updatedcrhistian@gmail.com";
+        final String password = "123456";
+
+        //All of this fields are admin's, which means they are not cached so all are null/empty
+        final List<RoleRequestDto> roles = new ArrayList<>();
+        final Boolean enabled = null;
+        final Long personId = null;
+
+        AccountUpdateRequestDto requestDto = new AccountUpdateRequestDto(email, password, enabled, roles, personId);
+
+        mockMvc.perform(patch("/api/accounts/" + accountId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isOk());
+
+        Cache cache = cacheManager.getCache(ACCOUNT);
+
+        assertThat(cache).isNotNull();
+
+        AccountUserResponseDto cachedResponse = cache.get(accountId, AccountUserResponseDto.class);
+
+        assertThat(cachedResponse).isNotNull();
+    }
+
+    @Test
+    @Sql(value = {"/personinserts.sql", "/accountinserts.sql"}, executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+    void shouldNotCacheResponseWhenClientIsAdminAuthorityAndIsUpdated() throws Exception { 
+        doReturn(true).when(identityVerificationService).isAdminAuthority();
+
+        final Long accountId = 1L;
+        final String email = "updatedcrhistian@gmail.com";
+        final String password = "123456";
+
+        //All of this fields are admin's, which means they are not cached so all are null/empty
+        final List<RoleRequestDto> roles = new ArrayList<>();
+        final Boolean enabled = null;
+        final Long personId = null;
+
+        AccountUpdateRequestDto requestDto = new AccountUpdateRequestDto(email, password, enabled, roles, personId);
+
+        mockMvc.perform(patch("/api/accounts/" + accountId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isOk());
+
+        Cache cache = cacheManager.getCache(ACCOUNT);
+
+        AccountResponseDto cachedResponse = cache.get(accountId, AccountResponseDto.class);
+
+        assertThat(cachedResponse).isNull();
+    }
+
+    @Test
+    @Sql(value = {"/personinserts.sql", "/accountinserts.sql"}, executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+    void shouldRemoveCachedResponseWhenAccountIsDeleted() throws Exception {
+        final Long accountId = 1L;
+
+        final String email = "testemail@gmail.com";
+        final Long personId = 2L;
+
+        AccountUserResponseDto responseDtoToCache = new AccountUserResponseDto(email, personId);
+            
+        cacheManager.getCache(ACCOUNT).put(accountId, responseDtoToCache);
+
+        mockMvc.perform(delete("/api/accounts/" + accountId))
+            .andExpect(status().isOk());
+
+        AccountUserResponseDto cachedResponse = cacheManager.getCache(ACCOUNT).get(accountId, AccountUserResponseDto.class);
+
+        assertThat(cachedResponse).isNull();
+    }
+
+    @Test
+    @Sql(value = {"/personinserts.sql", "/accountinserts.sql"}, executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+    void shouldCacheResponseWhenIsRequestedByIdAndClientIsUserAuthority() throws Exception {
+        doReturn(false).when(identityVerificationService).isAdminAuthority();
+
+        final Long accountId = 1L;
+
+        mockMvc.perform(get("/api/accounts/" + accountId))
+            .andExpect(status().isOk());
+
+        Cache cache = cacheManager.getCache(ACCOUNT);
+
+        AccountUserResponseDto cachedResponse = cache.get(accountId, AccountUserResponseDto.class);
+
+        assertThat(cachedResponse).isNotNull();
+
+        MvcResult result = mockMvc.perform(get("/api/accounts/" + accountId))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        AccountUserResponseDto expectedResponseDto = objectMapper.readValue(result.getResponse().getContentAsString(), AccountUserResponseDto.class);
+
+        assertThat(expectedResponseDto).isEqualTo(cachedResponse);
+
+        verify(spyAccountRepository, times(2)).existsById(eq(accountId));
+        verify(identityVerificationService, times(2)).isAdminAuthority();
+        verify(spyAccountRepository, times(1)).findById(eq(accountId));
+        verifyNoMoreInteractions(spyAccountRepository);
+    }
+
+    @Test
+    @Sql(value = {"/personinserts.sql", "/accountinserts.sql"}, executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+    void shouldNotCacheResponseWhenClientIsAdminAuthority() throws Exception{
+        doReturn(true).when(identityVerificationService).isAdminAuthority();
+
+        final Long accountId = 1L;
+
+        mockMvc.perform(get("/api/accounts/" + accountId))
+            .andExpect(status().isOk());
+
+        Cache cache = cacheManager.getCache(ACCOUNT);
+
+        AccountAdminResponseDto cachedResponse = cache.get(accountId, AccountAdminResponseDto.class);
+
+        assertThat(cachedResponse).isNull();
+
+        mockMvc.perform(get("/api/accounts/" + accountId))
+            .andExpect(status().isOk());
+
+        verify(spyAccountRepository, times(2)).existsById(eq(accountId));
+        verify(identityVerificationService, times(2)).isAdminAuthority();
+        verify(spyAccountRepository, times(2)).findById(eq(accountId));
+        verifyNoMoreInteractions(spyAccountRepository);
+    }
+
+
+}

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountServiceUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountServiceUnitTest.java
@@ -34,6 +34,7 @@ import com.crhistianm.springboot.gallo.springboot_gallo.shared.FieldInfoErrorBui
 
 import static com.crhistianm.springboot.gallo.springboot_gallo.account.AccountData.*;
 import static com.crhistianm.springboot.gallo.springboot_gallo.person.PersonData.getPersonInstance;
+import static com.crhistianm.springboot.gallo.springboot_gallo.shared.cache.CacheModule.ACCOUNT;
 
 import com.crhistianm.springboot.gallo.springboot_gallo.person.Person;
 import com.crhistianm.springboot.gallo.springboot_gallo.shared.exception.NotFoundException;
@@ -154,8 +155,9 @@ class AccountServiceUnitTest {
             }
 
             @Test
-            void shouldReturnAccountUserResponseDtoWhenAuthorityIsUser() {
+            void shouldReturnAccountUserResponseDtoFromCacheUtilsWhenAuthorityIsUser() {
                 doReturn(false).when(identityVerificationService).isAdminAuthority();
+                doReturn(null).when(cacheManager).getCache(anyString());
 
                 final Long requestedId = 1L;
 
@@ -166,6 +168,7 @@ class AccountServiceUnitTest {
                 verify(accountValidator, times(1)).validateByIdRequest(eq(requestedId));
                 verify(accountRepository, times(1)).existsById(eq(requestedId));
                 verify(accountRepository, times(1)).findById(eq(requestedId));
+                verify(cacheManager, times(1)).getCache(eq(ACCOUNT));
             }
 
             @Test

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountServiceUnitTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountServiceUnitTest.java
@@ -23,6 +23,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
@@ -61,33 +63,20 @@ class AccountServiceUnitTest {
     @Mock
     PasswordEncoder passwordEncoder;
 
+    @Mock
+    private CacheManager cacheManager;
+
+    @Mock
+    private IdentityVerificationService identityVerificationService;
+
+    @Mock
+    private Cache cache;
+
     @InjectMocks
     AccountService accountService;
 
     @Nested
     class ViewModuleTest{
-
-        @BeforeEach
-        void setUp(){
-            lenient().doAnswer(invo -> {
-                FieldInfoError field = null;
-                if(invo.getArgument(0, Long.class).equals(120L)) {
-                    field = new FieldInfoErrorBuilder().name("error").build();
-                    throw new ValidationServiceException(new ArrayList<>(List.of(field)));
-                }
-                return Optional.ofNullable(field);
-            }).when(accountValidator).validateByIdRequest(anyLong());
-            lenient().when(accountRepository.findById(anyLong())).thenAnswer(invo -> {
-                Optional<Account> accountOptional = Optional.empty();
-                if(invo.getArgument(0, Long.class) == 1L) accountOptional = givenAccountEntityAdmin();
-                if(invo.getArgument(0, Long.class) == 120L) {
-                    Account account = givenAccountEntityAdmin().orElseThrow();
-                    account.getPerson().setId(120L);
-                    accountOptional = Optional.of(account);
-                }
-                return accountOptional;
-            });
-        }
 
         @Test
         void testGetBy() {
@@ -117,38 +106,82 @@ class AccountServiceUnitTest {
             verify(accountRepository, times(1)).findBy(any(Pageable.class));
         }
 
-        @Test
-        void testGetByIdNotFound(){
-            assertThrows(NotFoundException.class, () -> {
-                accountService.getById(2L);
-            });
-            verify(accountRepository, times(1)).findById(anyLong());
-            verifyNoInteractions(accountValidator);
-            verifyNoInteractions(accountValidationService);
-        }
+        @Nested
+        class GetByIdMethodTest {
 
-        @Test
-        void testGetById(){
-            when(accountValidationService.settleResponseType(any(Account.class))).thenAnswer(invo ->
-                    AccountMapper.entityToAdminResponse(invo.getArgument(0,Account.class)));
+            @BeforeEach
+            void setUp(){
 
-            assertEquals("admin@gmail.com", accountService.getById(1L).getEmail());
-            verify(accountRepository, times(1)).findById(anyLong());
-            verify(accountValidationService, times(1)).settleResponseType(any(Account.class));
-        }
+                lenient().doAnswer(invo -> {
+                    FieldInfoError field = null;
+                    if(invo.getArgument(0, Long.class).equals(120L)) {
+                        field = new FieldInfoErrorBuilder().name("error").build();
+                        throw new ValidationServiceException(new ArrayList<>(List.of(field)));
+                    }
+                    return Optional.ofNullable(field);
+                }).when(accountValidator).validateByIdRequest(anyLong());
 
-        @Test
-        void shouldThrowExceptionWhenRequestByIdIsInvalid() {
-            FieldInfoError field = null;
+                lenient().when(accountRepository.existsById(anyLong())).thenAnswer(invo -> {
+                    return invo.getArgument(0, Long.class) == 1L || invo.getArgument(0, Long.class) == 120L;
+                });
 
-            field = assertThatExceptionOfType(ValidationServiceException.class)
-                .isThrownBy(() -> accountService.getById(120L)).actual().getFieldErrors().get(0);
-            assertThat(field).isNotNull();
-            assertThat(field).extracting(FieldInfoError::getName).isEqualTo("error");
+                lenient().doReturn(givenAccountEntityAdmin()).when(accountRepository).findById(anyLong());
 
-            verify(accountRepository, times(1)).findById(eq(120L));
-            verify(accountValidator).validateByIdRequest(eq(120L));
-            verifyNoInteractions(accountValidationService);
+            }
+
+            @Test
+            void testGetByIdNotFound(){
+                assertThrows(NotFoundException.class, () -> {
+                    accountService.getById(2L);
+                });
+                verify(accountRepository, times(1)).existsById(anyLong());
+                verifyNoInteractions(accountValidator);
+                verifyNoInteractions(accountValidationService);
+            }
+
+            @Test
+            void shouldReturnAccountAdminResponseDtoWhenAuthorityIsAdmin() {
+                doReturn(true).when(identityVerificationService).isAdminAuthority();
+                final Long requestedId = 1L;
+
+                final AccountResponseDto expectedResponse = accountService.getById(requestedId);
+
+                assertThat(expectedResponse).isInstanceOf(AccountAdminResponseDto.class);
+
+                verify(accountValidator, times(1)).validateByIdRequest(eq(requestedId));
+                verify(accountRepository, times(1)).existsById(eq(requestedId));
+                verify(accountRepository, times(1)).findById(eq(requestedId));
+            }
+
+            @Test
+            void shouldReturnAccountUserResponseDtoWhenAuthorityIsUser() {
+                doReturn(false).when(identityVerificationService).isAdminAuthority();
+
+                final Long requestedId = 1L;
+
+                final AccountResponseDto expectedResponse = accountService.getById(requestedId);
+
+                assertThat(expectedResponse).isInstanceOf(AccountUserResponseDto.class);
+
+                verify(accountValidator, times(1)).validateByIdRequest(eq(requestedId));
+                verify(accountRepository, times(1)).existsById(eq(requestedId));
+                verify(accountRepository, times(1)).findById(eq(requestedId));
+            }
+
+            @Test
+            void shouldThrowExceptionWhenRequestByIdIsInvalid() {
+                FieldInfoError field = null;
+
+                field = assertThatExceptionOfType(ValidationServiceException.class)
+                    .isThrownBy(() -> accountService.getById(120L)).actual().getFieldErrors().get(0);
+                assertThat(field).isNotNull();
+                assertThat(field).extracting(FieldInfoError::getName).isEqualTo("error");
+
+                verify(accountRepository, times(1)).existsById(eq(120L));
+                verify(accountValidator).validateByIdRequest(eq(120L));
+                verifyNoInteractions(accountValidationService);
+            }
+
         }
 
     }
@@ -158,6 +191,8 @@ class AccountServiceUnitTest {
 
         @BeforeEach
         void setUp(){
+            lenient().doReturn(cache).when(cacheManager).getCache(anyString());
+
             Person person = getPersonInstance();
             person.setId(1L);
             person.setFirstName("one");
@@ -243,6 +278,8 @@ class AccountServiceUnitTest {
 
         @BeforeEach
         void setUp() {
+            lenient().doReturn(cache).when(cacheManager).getCache(anyString());
+
             lenient().doAnswer(invo -> {
                 Person person = getPersonInstance();
                 person.setId(1L);


### PR DESCRIPTION
This PR implements Redis cache to account client user endpoints furtherly described as follows:

### Endpoints with cache implementation:

- ACCOUNT POST `api/accounts`

- ACCOUNT PATCH `api/accounts/{any ID}`

- ACCOUNT DELETE `api/accounts/{any ID}`

- ACCOUNT GET `api/accounts/{any ID}`

Previous endpoints cache implementation are only available for user authority, which is expected to be the most concurrent on requests.

>[!NOTE]
> Tests for this module cache implementation are included in this PR.


