### PR TITLE
Remove coupling with get method in person cache delete test

### DIFF
--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonServiceCacheTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonServiceCacheTest.java
@@ -191,8 +191,12 @@ class PersonServiceCacheTest {
     void shouldRemoveCachedResponseWhenPersonIsDeleted() throws Exception {
         final Long personId = 1L;
 
-        mockMvc.perform(get("/api/persons/" + personId))
-            .andExpect(status().isOk());
+        final String firstName = "example";
+
+        PersonResponseDto responseToCache = new PersonResponseDto();
+        responseToCache.setFirstName(firstName);
+
+        cacheManager.getCache("PERSON").put(personId, responseToCache);
 
         PersonResponseDto cachedResponse = cacheManager.getCache("PERSON").get(personId, PersonResponseDto.class);
 


### PR DESCRIPTION
Before refactor get method had to be called in order to test delete scenario.

### Solved:
Resolves #233 