### PR TITLE
Add person module cache 

### DIFF
--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseService.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseService.java
@@ -1,8 +1,11 @@
 package com.crhistianm.springboot.gallo.springboot_gallo.exercise;
 
+import static com.crhistianm.springboot.gallo.springboot_gallo.shared.cache.CacheModule.EXERCISE;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +18,7 @@ class ExerciseService {
         this.exerciseRepository = exerciseRepository;
     }
 
+    @Cacheable(value = EXERCISE, key = "#root.methodName")
     @Transactional(readOnly = true)
     List<ExerciseResponseDto> getAll() {
         List<ExerciseResponseDto> responseList = exerciseRepository.findAll()

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/cache/CacheModule.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/cache/CacheModule.java
@@ -3,4 +3,5 @@ package com.crhistianm.springboot.gallo.springboot_gallo.shared.cache;
 public class CacheModule {
     public static final String PERSON = "PERSON";
     public static final String ACCOUNT = "ACCOUNT";
+    public static final String EXERCISE = "EXERCISE";
 }

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/config/RedisConfig.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/shared/config/RedisConfig.java
@@ -19,6 +19,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import static com.crhistianm.springboot.gallo.springboot_gallo.shared.cache.CacheModule.PERSON;
 import static com.crhistianm.springboot.gallo.springboot_gallo.shared.cache.CacheModule.ACCOUNT;
+import static com.crhistianm.springboot.gallo.springboot_gallo.shared.cache.CacheModule.EXERCISE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
@@ -58,6 +59,7 @@ public class RedisConfig {
 
         cacheConfigurations.put(PERSON, redisCacheConfiguration.entryTtl(Duration.ofHours(1)));
         cacheConfigurations.put(ACCOUNT, redisCacheConfiguration.entryTtl(Duration.ofHours(2)));
+        cacheConfigurations.put(EXERCISE, redisCacheConfiguration.entryTtl(Duration.ofHours(24)));
 
         RedisCacheManager redisCacheManager = RedisCacheManager
             .builder(connectionFactory)

--- a/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseServiceCacheTest.java
+++ b/backend/src/test/java/com/crhistianm/springboot/gallo/springboot_gallo/exercise/ExerciseServiceCacheTest.java
@@ -1,0 +1,99 @@
+package com.crhistianm.springboot.gallo.springboot_gallo.exercise;
+
+import static com.crhistianm.springboot.gallo.springboot_gallo.shared.cache.CacheModule.EXERCISE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@TestPropertySource(properties = {
+"spring.datasource.url=jdbc:h2:mem:testdb",
+"spring.datasource.driverClassName=org.h2.Driver",
+"spring.datasource.username=sa",
+"spring.datasource.password=password",
+"spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+"spring.docker.compose.enabled=false"
+})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc(addFilters = false)
+@Testcontainers
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class ExerciseServiceCacheTest {
+
+
+    @Container
+    @ServiceConnection
+    private static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:7.4-alpine"))
+        .withExposedPorts(6379);
+
+    @Autowired
+    private MockMvc mockMvc ;
+
+    @MockitoSpyBean
+    private ExerciseRepository spyExerciseRepository;
+
+    @Autowired
+    private ExerciseRepository exerciseRepository;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        cacheManager.getCache(EXERCISE).clear();
+        exerciseRepository.deleteAll();
+    }
+
+    @Test
+    @Sql(value = {"/exerciseinserts.sql"}, executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+    void shouldCacheGetAllExerciseList() throws Exception {
+
+        MvcResult result = mockMvc.perform(get("/api/exercises"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        List<ExerciseResponseDto> expectedResultList = objectMapper
+            .readValue(result.getResponse().getContentAsString(), new TypeReference<List<ExerciseResponseDto>>(){});
+
+        String cachedResponseString = cacheManager.getCache(EXERCISE).get("getAll").get().toString();
+
+        List<ExerciseResponseDto> expectedCachedString = objectMapper
+            .readValue(cachedResponseString, objectMapper.getTypeFactory().constructCollectionType(List.class, ExerciseResponseDto.class));
+
+        assertThat(expectedResultList).isEqualTo(expectedCachedString);
+
+        verify(spyExerciseRepository, times(1)).findAll();
+    }
+    
+}


### PR DESCRIPTION
This PR implements Redis cache to exercise client user endpoints furtherly described as follows:

### Endpoints with cache implementation:

- EXERCISE GET ALL `api/accounts`

>[!NOTE]
> Tests for this module cache implementation are included in this PR.


