### PR TITLE
Add missing admin authority endpoints OpenAPI definition 

### DIFF
--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountController.java
@@ -36,6 +36,15 @@ class AccountController {
     @PostMapping
     @SecurityRequirements(value = {})
     @Operation( 
+        requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            content = @Content(
+                schema = @Schema(
+                    implementation = AccountRequestDto.class,
+                    requiredProperties = {"password", "email", "personId"}
+                )
+            )
+        ),
         responses = {
             @ApiResponse(responseCode = "404",content = {}), 
             @ApiResponse
@@ -71,7 +80,10 @@ class AccountController {
         return ResponseEntity.ok(accountService.getById(id));
     }
 
+    //Encontra como aplicarlo a los que faltan que son solo de admin y haces una PR que se llame algo como docs/missing-admin-specification
+    //Asi pones junto a los admin field lo que falta de admin endpoints en un commit como "docs: add missing only admin functionalities OpenApi specifications"
     @Operation( 
+        description = "ADMIN ENDPOINT",
         responses = {
             @ApiResponse(responseCode = "404",content = {}),
             @ApiResponse(responseCode = "400",content = {})

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountRequestDto.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountRequestDto.java
@@ -3,6 +3,7 @@ package com.crhistianm.springboot.gallo.springboot_gallo.account;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -10,6 +11,7 @@ import jakarta.validation.constraints.NotNull;
 //Id not in dto as it is auto incremental on db
 final class AccountRequestDto extends AbstractAccountRequestDto {
 
+    @Schema(description = "ADMIN FIELD")
     private final boolean admin;
 
     @JsonCreator

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountUpdateRequestDto.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/account/AccountUpdateRequestDto.java
@@ -8,6 +8,7 @@ import com.crhistianm.springboot.gallo.springboot_gallo.shared.group.SecondCheck
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
 
@@ -24,9 +25,9 @@ final class AccountUpdateRequestDto extends AbstractAccountRequestDto {
     (
      @JsonProperty(value = "email") String email,
      @JsonProperty(value = "password") String password,
-     @JsonProperty(value = "enabled") Boolean enabled,
-     @JsonProperty(value = "roles") List<RoleRequestDto> roles,
-     @JsonProperty(value = "personId") Long personId
+     @JsonProperty(value = "enabled")@Schema(description = "ADMIN FIELD") Boolean enabled,
+     @JsonProperty(value = "roles") @Schema(description = "ADMIN FIELD") List<RoleRequestDto> roles,
+     @JsonProperty(value = "personId") @Schema(description = "ADMIN FIELD") Long personId
      ) {
         super(email, password, personId);
         this.roles = roles == null ? List.of() : List.copyOf(roles);

--- a/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonController.java
+++ b/backend/src/main/java/com/crhistianm/springboot/gallo/springboot_gallo/person/PersonController.java
@@ -42,6 +42,7 @@ class PersonController {
 
     @GetMapping
     @Operation(
+        description = "ADMIN ENDPOINT",
         responses = {
             @ApiResponse(responseCode = "404",content = {}),
         }


### PR DESCRIPTION
This PR adds the following admin documentation to apidocs endpoint:

### Definitions added:
- Person 
   - `viewBy` endpoint admin only description
- Account 
    - `viewBy` endpoint admin only description
    - `update` endpoint admin only fields descriptions
    - `create` endpoint admin only field description 

### Solved:

Resolves #232
